### PR TITLE
Feat: 워크스페이스 관리 페이지 구현

### DIFF
--- a/placeit-frontend/src/app/(dashboard)/workspace/page.tsx
+++ b/placeit-frontend/src/app/(dashboard)/workspace/page.tsx
@@ -2,30 +2,212 @@
 
 import React from 'react';
 import { MainLayout } from '@/components/layout/MainLayout';
+import { StatCard } from '@/components/management/StatCard';
+import SearchFilterBar, {
+  type FilterItem,
+} from '@/components/management/SearchFilterBar';
+import { LayoutGrid, Users, Crown, Mail } from 'lucide-react';
+import AddWorkspaceDialog, {
+  type NewWorkspace,
+} from '@/components/management/AddWorkspaceDialog';
+import WorkspaceCard from '@/components/management/WorkspaceCard'; // ✅ 카드 컴포넌트 import
 
-export default function WorkspacePage() {
+type WSStatus = 'active' | 'inactive';
+type WSFilter = 'all' | WSStatus;
+
+const FILTERS: FilterItem<WSFilter>[] = [
+  { key: 'all', label: '전체' },
+  { key: 'active', label: '활성' },
+  { key: 'inactive', label: '비활성' },
+];
+
+type Workspace = {
+  id: string;
+  name: string;
+  description: string; // ✅ 카드용
+  imageUrl?: string; // ✅ 카드용
+  inviteCode: string;
+  owner: string;
+  members: number;
+  status: WSStatus;
+  createdAt: string;
+};
+
+export default function WorkspacesPage() {
+  const [q, setQ] = React.useState('');
+  const [k, setK] = React.useState<WSFilter>('all');
+
+  const [workspaces, setWorkspaces] = React.useState<Workspace[]>([
+    {
+      id: 'ws_1',
+      name: 'Startup Hub',
+      description: '혁신적인 스타트업들이 모인 공간',
+      imageUrl: 'https://images.unsplash.com/photo-1497366216548-37526070297c',
+      inviteCode: 'CORE-1A2B',
+      owner: '홍길동',
+      members: 18,
+      status: 'active',
+      createdAt: '2025-08-01',
+    },
+    {
+      id: 'ws_2',
+      name: 'Tech Valley',
+      description: '엔지니어링과 연구 중심의 워크스페이스',
+      imageUrl: 'https://images.unsplash.com/photo-1557804506-669a67965ba0',
+      inviteCode: 'DESN-9XY4',
+      owner: '김디자',
+      members: 22,
+      status: 'active',
+      createdAt: '2025-07-21',
+    },
+    {
+      id: 'ws_3',
+      name: 'Creative Studio',
+      description: '디자인 씽킹과 프로토타이핑을 위한 공간',
+      imageUrl: 'https://images.unsplash.com/photo-1519389950473-47ba0277781c',
+      inviteCode: 'ARCH-7788',
+      owner: '이아카',
+      members: 14,
+      status: 'inactive',
+      createdAt: '2025-06-15',
+    },
+  ]);
+
+  const pendingInvites = 2;
+
+  const totalWorkspaces = workspaces.length;
+  const totalMembers = workspaces.reduce((sum, w) => sum + w.members, 0);
+  const activeWorkspaces = workspaces.filter(w => w.status === 'active').length;
+
+  // 검색
+  const filtered = React.useMemo(() => {
+    const query = q.trim().toLowerCase();
+    const norm = (s: string) => s.toLowerCase();
+    return workspaces.filter(w => {
+      const statusOk = k === 'all' ? true : w.status === k;
+      const searchOk =
+        !query ||
+        norm(w.name).includes(query) ||
+        norm(w.inviteCode).includes(query) ||
+        norm(w.owner).includes(query);
+      return statusOk && searchOk;
+    });
+  }, [workspaces, q, k]);
+
+  const handleCreate = (ws: NewWorkspace) => {
+    const id = (crypto as any)?.randomUUID?.() ?? `ws_${Date.now()}`;
+    const inviteCode = `WS-${Math.random()
+      .toString(36)
+      .slice(2, 6)
+      .toUpperCase()}${Math.floor(Math.random() * 90 + 10)}`;
+
+    setWorkspaces(prev => [
+      {
+        id,
+        name: ws.name,
+        description: ws.description, // ✅ 다이얼로그 입력 반영
+        imageUrl:
+          'https://images.unsplash.com/photo-1497366216548-37526070297c', // 기본 이미지
+        owner: '나', // 로그인 유저명으로 교체
+        inviteCode,
+        members: 1,
+        status: 'active',
+        createdAt: new Date().toISOString().slice(0, 10),
+      },
+      ...prev,
+    ]);
+  };
+
+  const handleEdit = (id: string) => {
+    // TODO: 수정 다이얼로그 열기
+    alert(`edit ${id}`);
+  };
+
+  const handleDelete = (id: string) => {
+    if (!confirm('정말 삭제하시겠어요?')) return;
+    setWorkspaces(prev => prev.filter(w => w.id !== id));
+  };
+
+  const handleToggleStatus = (id: string, next: WSStatus) => {
+    setWorkspaces(prev =>
+      prev.map(w => (w.id === id ? { ...w, status: next } : w))
+    );
+  };
+
   return (
-    <MainLayout activePage="workspace">
-      <div className="p-6">
-        <div className="mb-8">
-          <h1 className="text-3xl font-bold text-gray-900 mb-2">
-            워크스페이스 관리
-          </h1>
-          <p className="text-gray-600">
-            워크스페이스 설정과 초대코드를 관리하세요
-          </p>
+    <MainLayout activePage="workspaces">
+      <div className="space-y-6 p-6">
+        {/* 헤더 */}
+        <div className="flex items-start justify-between">
+          <div>
+            <h1 className="mb-2 text-3xl font-bold text-gray-900">
+              워크스페이스 관리
+            </h1>
+            <p className="text-gray-600">
+              워크스페이스를 생성하고 멤버를 초대하여 관리하세요
+            </p>
+          </div>
+          <AddWorkspaceDialog onCreate={handleCreate} />
         </div>
 
-        <div className="bg-white rounded-lg border p-6">
-          <p className="text-gray-600">
-            워크스페이스 관리 기능이 준비 중입니다.
-          </p>
+        {/* 통계 */}
+        <div className="grid w-full grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-4">
+          <StatCard
+            label="전체 워크스페이스"
+            value={totalWorkspaces}
+            icon={LayoutGrid}
+            valueClassName="text-blue-600"
+          />
+          <StatCard
+            label="전체 멤버"
+            value={totalMembers}
+            icon={Users}
+            valueClassName="text-emerald-600"
+          />
+          <StatCard
+            label="활성 워크스페이스"
+            value={activeWorkspaces}
+            icon={Crown}
+            valueClassName="text-purple-600"
+          />
+          <StatCard
+            label="대기 중 초대"
+            value={pendingInvites}
+            icon={Mail}
+            valueClassName="text-orange-600"
+          />
+        </div>
+
+        {/* 검색 */}
+        <SearchFilterBar<WSFilter>
+          placeholder="워크스페이스명, 초대코드, 소유자로 검색…"
+          query={q}
+          onQueryChange={setQ}
+          filters={FILTERS}
+          activeKey={k}
+          onChange={setK}
+          className="mt-2"
+        />
+
+        {/* 카드 그리드 */}
+        <div className="grid grid-flow-row-dense gap-6 [grid-template-columns:repeat(auto-fill,minmax(300px,1fr))]">
+          {filtered.map(w => (
+            <WorkspaceCard
+              key={w.id}
+              id={w.id}
+              name={w.name}
+              description={w.description}
+              owner={w.owner}
+              inviteCode={w.inviteCode}
+              status={w.status}
+              imageUrl={w.imageUrl}
+              onEdit={handleEdit}
+              onDelete={handleDelete}
+              onToggleStatus={handleToggleStatus}
+            />
+          ))}
         </div>
       </div>
     </MainLayout>
   );
 }
-
-
-
-

--- a/placeit-frontend/src/components/management/AddWorkspaceDialog.tsx
+++ b/placeit-frontend/src/components/management/AddWorkspaceDialog.tsx
@@ -1,0 +1,274 @@
+'use client';
+
+import * as React from 'react';
+import * as Dialog from '@radix-ui/react-dialog';
+import { X as XIcon, Plus, Image as ImageIcon, Trash2 } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+
+export type NewWorkspace = {
+  name: string;
+  description: string;
+  owner: string;
+  maxMembers: number;
+  /** 서버로 업로드할 때 file 혹은 미리보기용 dataUrl 중 하나를 활용하세요 */
+  imageFile?: File | null;
+  imageUrl?: string | null; // objectURL or dataURL (preview)
+};
+
+type Props = {
+  onCreate: (data: NewWorkspace) => void;
+};
+
+export default function AddWorkspaceDialog({ onCreate }: Props) {
+  const [open, setOpen] = React.useState(false);
+
+  const [name, setName] = React.useState('');
+  const [description, setDescription] = React.useState('');
+  const [owner, setOwner] = React.useState('');
+  const [maxMembers, setMaxMembers] = React.useState<number | ''>('');
+
+  const [imageFile, setImageFile] = React.useState<File | null>(null);
+  const [imageUrl, setImageUrl] = React.useState<string | null>(null); // preview
+
+  const [submitting, setSubmitting] = React.useState(false);
+  const [error, setError] = React.useState<string | null>(null);
+
+  const reset = () => {
+    setName('');
+    setDescription('');
+    setOwner('');
+    setMaxMembers('');
+    setImageFile(null);
+    if (imageUrl) URL.revokeObjectURL(imageUrl);
+    setImageUrl(null);
+    setError(null);
+  };
+
+  const validate = () => {
+    if (!name.trim()) return '워크스페이스명을 입력하세요.';
+    if (!description.trim()) return '설명을 입력하세요.';
+    if (!owner.trim()) return '소유자를 입력하세요.';
+    const n = Number(maxMembers);
+    if (!Number.isFinite(n) || n < 1)
+      return '최대 멤버 수는 1 이상의 숫자여야 합니다.';
+    // 이미지 필수는 아님. 필수로 하려면 아래 주석 해제
+    // if (!imageFile) return '이미지를 선택해주세요.';
+    return null;
+  };
+
+  const onSelectImage: React.ChangeEventHandler<HTMLInputElement> = e => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+
+    // 간단한 타입/용량 체크(옵션)
+    if (!file.type.startsWith('image/')) {
+      setError('이미지 파일만 업로드할 수 있습니다.');
+      return;
+    }
+    // 5MB 제한 예시
+    if (file.size > 5 * 1024 * 1024) {
+      setError('이미지 용량은 5MB 이하만 가능합니다.');
+      return;
+    }
+
+    setError(null);
+    setImageFile(file);
+    // object URL로 즉시 미리보기
+    const url = URL.createObjectURL(file);
+    // 기존 url revoke
+    if (imageUrl) URL.revokeObjectURL(imageUrl);
+    setImageUrl(url);
+  };
+
+  const clearImage = () => {
+    setImageFile(null);
+    if (imageUrl) URL.revokeObjectURL(imageUrl);
+    setImageUrl(null);
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const v = validate();
+    if (v) {
+      setError(v);
+      return;
+    }
+    setSubmitting(true);
+    try {
+      onCreate({
+        name: name.trim(),
+        description: description.trim(),
+        owner: owner.trim(),
+        maxMembers: Number(maxMembers),
+        imageFile,
+        imageUrl, // 미리보기 url (서버 업로드 완료 후엔 서버 url로 교체)
+      });
+      reset();
+      setOpen(false);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Dialog.Root
+      open={open}
+      onOpenChange={o => {
+        setOpen(o);
+        if (!o) reset();
+      }}
+    >
+      {/* 트리거: 파란색 버튼 */}
+      <Dialog.Trigger asChild>
+        <Button className="gap-2 bg-blue-600 hover:bg-blue-700 text-white">
+          <Plus className="h-4 w-4" />
+          워크스페이스 생성
+        </Button>
+      </Dialog.Trigger>
+
+      <Dialog.Portal>
+        <Dialog.Overlay className="fixed inset-0 z-40 bg-black/40 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=open]:fade-in-0 data-[state=closed]:fade-out-0" />
+        <Dialog.Content className="fixed left-1/2 top-1/2 z-50 w-[95vw] max-w-xl -translate-x-1/2 -translate-y-1/2 rounded-2xl border bg-white p-6 shadow-xl focus:outline-none">
+          <div className="mb-4 flex items-start justify-between">
+            <Dialog.Title className="text-xl font-semibold text-gray-900">
+              새 워크스페이스 생성
+            </Dialog.Title>
+            <Dialog.Close asChild>
+              <button
+                className="inline-flex h-8 w-8 items-center justify-center rounded-full text-gray-500 hover:bg-gray-100 hover:text-gray-700"
+                aria-label="Close"
+              >
+                <XIcon className="h-5 w-5" />
+              </button>
+            </Dialog.Close>
+          </div>
+
+          <form onSubmit={handleSubmit} className="space-y-4">
+            {/* 워크스페이스명 */}
+            <div>
+              <label className="mb-1 block text-sm font-medium text-gray-700">
+                워크스페이스명 <span className="text-rose-500">*</span>
+              </label>
+              <input
+                type="text"
+                className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm outline-none ring-0 focus:border-primary-400"
+                placeholder="예: Place It"
+                value={name}
+                onChange={e => setName(e.target.value)}
+              />
+            </div>
+
+            {/* 설명 */}
+            <div>
+              <label className="mb-1 block text-sm font-medium text-gray-700">
+                설명 <span className="text-rose-500">*</span>
+              </label>
+              <textarea
+                className="w-full resize-y rounded-md border border-gray-300 px-3 py-2 text-sm outline-none ring-0 focus:border-primary-400"
+                placeholder="워크스페이스의 목적과 특징을 설명해주세요"
+                rows={4}
+                value={description}
+                onChange={e => setDescription(e.target.value)}
+              />
+            </div>
+
+            {/* 소유자 */}
+            <div>
+              <label className="mb-1 block text-sm font-medium text-gray-700">
+                소유자 <span className="text-rose-500">*</span>
+              </label>
+              <input
+                type="text"
+                className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm outline-none ring-0 focus:border-primary-400"
+                placeholder="예: 홍길동"
+                value={owner}
+                onChange={e => setOwner(e.target.value)}
+              />
+            </div>
+
+            {/* 최대 멤버 수 */}
+            <div>
+              <label className="mb-1 block text-sm font-medium text-gray-700">
+                최대 멤버 수 <span className="text-rose-500">*</span>
+              </label>
+              <input
+                type="number"
+                min={1}
+                inputMode="numeric"
+                className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm outline-none ring-0 focus:border-primary-400"
+                placeholder="예: 50"
+                value={maxMembers}
+                onChange={e =>
+                  setMaxMembers(
+                    e.target.value === '' ? '' : Number(e.target.value)
+                  )
+                }
+              />
+            </div>
+
+            {/* 이미지 업로드 */}
+            <div>
+              <label className="mb-1 block text-sm font-medium text-gray-700">
+                이미지 업로드
+              </label>
+
+              {imageUrl ? (
+                <div className="flex items-center gap-3">
+                  <img
+                    src={imageUrl}
+                    alt="미리보기"
+                    className="h-20 w-32 rounded-md object-cover border"
+                  />
+                  <Button
+                    type="button"
+                    variant="outline"
+                    className="gap-2 border-gray-300"
+                    onClick={clearImage}
+                  >
+                    <Trash2 className="h-4 w-4" />
+                    제거
+                  </Button>
+                </div>
+              ) : (
+                <label className="flex cursor-pointer items-center gap-2 rounded-md border border-dashed border-gray-300 px-3 py-2 text-sm text-gray-700 hover:bg-gray-50">
+                  <ImageIcon className="h-4 w-4" />
+                  <span>이미지 선택</span>
+                  <input
+                    type="file"
+                    accept="image/*"
+                    onChange={onSelectImage}
+                    className="hidden"
+                  />
+                </label>
+              )}
+
+              <p className="mt-1 text-xs text-gray-500">
+                JPG/PNG, 5MB 이하 권장
+              </p>
+            </div>
+
+            {error && (
+              <p className="text-sm text-rose-600" role="alert">
+                {error}
+              </p>
+            )}
+
+            <div className="mt-2 flex items-center justify-end gap-2">
+              <Dialog.Close asChild>
+                <button
+                  type="button"
+                  className="rounded-md border border-gray-300 bg-white px-4 py-2 text-sm text-gray-700 hover:bg-gray-50"
+                >
+                  취소
+                </button>
+              </Dialog.Close>
+              <Button type="submit" disabled={submitting}>
+                {submitting ? '생성 중...' : '생성'}
+              </Button>
+            </div>
+          </form>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}

--- a/placeit-frontend/src/components/management/WorkspaceCard.tsx
+++ b/placeit-frontend/src/components/management/WorkspaceCard.tsx
@@ -1,0 +1,149 @@
+'use client';
+
+import * as React from 'react';
+import { Edit3, Trash2, Copy, UserCircle2 } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+
+export type WorkspaceStatus = 'active' | 'inactive';
+
+export type WorkspaceCardProps = {
+  id: string;
+  name: string;
+  description: string;
+  owner: string;
+  inviteCode: string;
+  status: WorkspaceStatus;
+  imageUrl?: string;
+
+  onEdit?: (id: string) => void;
+  onDelete?: (id: string) => void;
+  onCopyInvite?: (inviteCode: string) => void;
+  /** 상태 토글: 현재 상태를 보고 next 계산해서 넘겨줌 */
+  onToggleStatus?: (id: string, next: WorkspaceStatus) => void;
+};
+
+export default function WorkspaceCard({
+  id,
+  name,
+  description,
+  owner,
+  inviteCode,
+  status,
+  imageUrl = 'https://images.unsplash.com/photo-1497366216548-37526070297c',
+  onEdit,
+  onDelete,
+  onCopyInvite,
+  onToggleStatus,
+}: WorkspaceCardProps) {
+  const [copied, setCopied] = React.useState(false);
+  const isActive = status === 'active';
+
+  const handleCopy = async () => {
+    try {
+      if (onCopyInvite) onCopyInvite(inviteCode);
+      else await navigator.clipboard.writeText(inviteCode);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1200);
+    } catch {}
+  };
+
+  const handleToggle = () => {
+    const next: WorkspaceStatus = isActive ? 'inactive' : 'active';
+    onToggleStatus?.(id, next);
+  };
+
+  return (
+    <div className="overflow-hidden rounded-2xl border bg-white shadow-sm transition hover:shadow-md">
+      {/* 이미지 + 상태 배지 */}
+      <div className="relative">
+        <img
+          src={imageUrl}
+          alt={`${name} cover`}
+          className="h-40 w-full object-cover"
+        />
+        <span
+          className={`absolute right-3 top-3 rounded-full px-2.5 py-1 text-xs font-semibold text-white shadow ${
+            isActive ? 'bg-emerald-600' : 'bg-gray-400'
+          }`}
+        >
+          {isActive ? '활성' : '비활성'}
+        </span>
+      </div>
+
+      {/* 본문 */}
+      <div className="p-4">
+        {/* 제목 + 액션 */}
+        <div className="mb-1 flex items-start justify-between gap-3">
+          <h3 className="line-clamp-1 text-lg font-semibold text-gray-900">
+            {name}
+          </h3>
+          <div className="flex shrink-0 items-center gap-1.5">
+            <Button
+              variant="outline"
+              size="icon"
+              className="h-8 w-8 border-gray-300"
+              onClick={() => onEdit?.(id)}
+              aria-label="워크스페이스 수정"
+              title="수정"
+            >
+              <Edit3 className="h-4 w-4" />
+            </Button>
+            <Button
+              variant="outline"
+              size="icon"
+              className="h-8 w-8 border-gray-300 text-rose-600 hover:text-rose-700"
+              onClick={() => onDelete?.(id)}
+              aria-label="워크스페이스 삭제"
+              title="삭제"
+            >
+              <Trash2 className="h-4 w-4" />
+            </Button>
+          </div>
+        </div>
+
+        {/* 설명 */}
+        <p className="mb-2 line-clamp-2 text-sm text-gray-600">{description}</p>
+
+        {/* 소유자 */}
+        <div className="mb-3 flex items-center gap-2 text-sm text-gray-700">
+          <UserCircle2 className="h-4 w-4 text-gray-500" />
+          <span className="truncate">소유자: {owner}</span>
+        </div>
+
+        {/* 초대 코드 + 복사 */}
+        <div className="rounded-xl border border-gray-200 bg-gray-50 p-2">
+          <div className="mb-1 text-xs text-gray-500">초대 코드</div>
+          <div className="flex items-center justify-between gap-2">
+            <code className="select-all text-sm tracking-wide text-gray-800">
+              {inviteCode}
+            </code>
+            <Button
+              variant="outline"
+              size="sm"
+              className="gap-1 border-gray-300"
+              onClick={handleCopy}
+              aria-label="초대 코드 복사"
+            >
+              <Copy className="h-4 w-4" />
+              {copied ? '복사됨' : '복사'}
+            </Button>
+          </div>
+        </div>
+
+        {/* 하단: 상태 토글 버튼 */}
+        <div className="mt-4 flex justify-end">
+          <Button
+            onClick={handleToggle}
+            className={
+              isActive
+                ? 'bg-rose-600 hover:bg-rose-700 text-white'
+                : 'bg-emerald-600 hover:bg-emerald-700 text-white'
+            }
+          >
+            {isActive ? '비활성화' : '활성화'}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## 상세내용
- 회의실 관리 페이지에서 사용했던 통계 스탯과 검색창 컴포넌트 재활용
  - 전체 워크스페이스, 전체 멤버, 활성 워크스페이스, 대기 중인 초대, 4가지 통계 스탯과 전체, 활성, 비활성, 3가지 필터링
- 워크스페이스별 카드 컴포넌트 생성
- 워크스페이스 비활성 버튼 만들면서 피그마도 수정

## 추가해야 할 기능
- 워크스페이스 카드 내용 수정 모달창 및 기능 구현
- 워크스페이스 삭제 기능 구현