### PR TITLE
Feat: 그룹 관리 페이지 구현

### DIFF
--- a/placeit-frontend/next.config.ts
+++ b/placeit-frontend/next.config.ts
@@ -2,6 +2,7 @@ import type { NextConfig } from 'next';
 
 const nextConfig: NextConfig = {
   images: {
+    domains: ['images.unsplash.com'],
     remotePatterns: [
       {
         protocol: 'http',

--- a/placeit-frontend/package-lock.json
+++ b/placeit-frontend/package-lock.json
@@ -406,16 +406,6 @@
       "integrity": "sha512-P5LUNhtbj6YfI3iJjw5EL9eUAG6OitD0W3fWQcpQjDRc/QIsL0tRNuO1PcDvPccWL1fSTXXdE1ds+l95DV/OFA==",
       "license": "MIT"
     },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.4.5",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.4.5.tgz",
-      "integrity": "sha512-++LApOtY0pEEz1zrd9vy1/zXVaVJJ/EbAF3u0fXIzPJEDtnITsBGbbK0EkM72amhl/R5b+5xx0Y/QhcVOpuulg==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/@esbuild/darwin-arm64": {
       "version": "0.25.9",
       "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.9.tgz",
@@ -826,6 +816,111 @@
       "optional": true,
       "os": [
         "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-darwin-x64": {
+      "version": "15.4.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.4.7.tgz",
+      "integrity": "sha512-qaMnEozKdWezlmh1OGDVFueFv2z9lWTcLvt7e39QA3YOvZHNpN2rLs/IQLwZaUiw2jSvxW07LxMCWtOqsWFNQg==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-gnu": {
+      "version": "15.4.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.4.7.tgz",
+      "integrity": "sha512-ny7lODPE7a15Qms8LZiN9wjNWIeI+iAZOFDOnv2pcHStncUr7cr9lD5XF81mdhrBXLUP9yT9RzlmSWKIazWoDw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-musl": {
+      "version": "15.4.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.4.7.tgz",
+      "integrity": "sha512-4SaCjlFR/2hGJqZLLWycccy1t+wBrE/vyJWnYaZJhUVHccpGLG5q0C+Xkw4iRzUIkE+/dr90MJRUym3s1+vO8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-gnu": {
+      "version": "15.4.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.4.7.tgz",
+      "integrity": "sha512-2uNXjxvONyRidg00VwvlTYDwC9EgCGNzPAPYbttIATZRxmOZ3hllk/YYESzHZb65eyZfBR5g9xgCZjRAl9YYGg==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-musl": {
+      "version": "15.4.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.4.7.tgz",
+      "integrity": "sha512-ceNbPjsFgLscYNGKSu4I6LYaadq2B8tcK116nVuInpHHdAWLWSwVK6CHNvCi0wVS9+TTArIFKJGsEyVD1H+4Kg==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-arm64-msvc": {
+      "version": "15.4.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.4.7.tgz",
+      "integrity": "sha512-pZyxmY1iHlZJ04LUL7Css8bNvsYAMYOY9JRwFA3HZgpaNKsJSowD09Vg2R9734GxAcLJc2KDQHSCR91uD6/AAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-x64-msvc": {
+      "version": "15.4.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.4.7.tgz",
+      "integrity": "sha512-HjuwPJ7BeRzgl3KrjKqD2iDng0eQIpIReyhpF5r4yeAHFwWRuAhfW92rWv/r3qeQHEwHsLRzFDvMqRjyM5DI6A==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
       ],
       "engines": {
         "node": ">= 10"

--- a/placeit-frontend/src/app/(dashboard)/users/groups/page.tsx
+++ b/placeit-frontend/src/app/(dashboard)/users/groups/page.tsx
@@ -1,0 +1,199 @@
+'use client';
+
+import React from 'react';
+import { MainLayout } from '@/components/layout/MainLayout';
+import { StatCard } from '@/components/management/StatCard';
+import { LayoutGrid, Users, Shield, Building2 } from 'lucide-react';
+import SearchFilterBar, {
+  type FilterItem,
+} from '@/components/management/SearchFilterBar';
+import AddGroupDialog, {
+  type NewGroup,
+} from '@/components/management/AddGroupDialog';
+import GroupCard, {
+  type GroupCardData,
+  type GroupType,
+} from '@/components/management/GroupCard';
+
+type GroupFilter = 'all' | GroupType; // 'project' 제거
+
+const GROUP_FILTERS: FilterItem<GroupFilter>[] = [
+  { key: 'all', label: '전체' },
+  { key: 'exec', label: '임원진' },
+  { key: 'admin', label: '관리자' },
+  { key: 'department', label: '부서' },
+];
+
+export default function GroupManagementPage() {
+  const [q, setQ] = React.useState('');
+  const [k, setK] = React.useState<GroupFilter>('all');
+
+  const [groups, setGroups] = React.useState<GroupCardData[]>([
+    {
+      id: 'g1',
+      name: '경영진',
+      type: 'exec',
+      description: '회사의 주요 의사결정을 담당하는 임원진 그룹',
+      leader: '이정우',
+      membersCount: 3,
+      maxMembers: 5,
+      createdAt: '2024-01-01T00:00:00Z',
+    },
+    {
+      id: 'g2',
+      name: '개발팀',
+      type: 'department',
+      description: '소프트웨어 개발 및 기술 관련 업무를 담당하는 팀',
+      leader: '박정호',
+      membersCount: 8,
+      maxMembers: 15,
+      createdAt: '2024-01-01T00:00:00Z',
+    },
+    {
+      id: 'g3',
+      name: '마케팅팀',
+      type: 'department',
+      description: '마케팅 전략 수립 및 브랜드 관리를 담당하는 팀',
+      leader: '김민지',
+      membersCount: 6,
+      maxMembers: 10,
+      createdAt: '2024-01-01T00:00:00Z',
+    },
+    {
+      id: 'g4',
+      name: '관리자',
+      type: 'admin',
+      description: '시스템 관리 권한을 가진 특별 그룹',
+      leader: '시스템관리자',
+      membersCount: 2,
+      maxMembers: 3,
+      createdAt: '2024-01-01T00:00:00Z',
+    },
+  ]);
+
+  // 상단 요약
+  const totalGroups = groups.length;
+  const totalMembers = groups.reduce((acc, g) => acc + g.membersCount, 0);
+  const adminGroups = groups.filter(g => g.type === 'admin').length;
+  const deptGroups = groups.filter(g => g.type === 'department').length;
+
+  // 검색 + 필터
+  const filtered = React.useMemo(() => {
+    const query = q.trim().toLowerCase();
+    return groups.filter(g => {
+      const kOk = k === 'all' ? true : g.type === k;
+      const qOk =
+        !query ||
+        g.name.toLowerCase().includes(query) ||
+        (g.description ?? '').toLowerCase().includes(query) ||
+        (g.leader ?? '').toLowerCase().includes(query);
+      return kOk && qOk;
+    });
+  }, [groups, q, k]);
+
+  // AddGroupDialog 연결
+  const handleAddGroup = (ng: NewGroup) => {
+    const id =
+      (typeof crypto !== 'undefined' &&
+        'randomUUID' in crypto &&
+        crypto.randomUUID()) ||
+      `g-${Date.now()}`;
+
+    // AddGroupDialog는 type이 'exec' | 'department' | 'admin' 이라고 가정
+    setGroups(prev => [
+      {
+        id,
+        name: ng.name,
+        type: ng.type as GroupType,
+        description: ng.description,
+        leader: ng.leader,
+        membersCount: 0,
+        maxMembers: Number(ng.maxMembers ?? 0),
+        createdAt: new Date(ng.createdAt).toISOString(),
+      },
+      ...prev,
+    ]);
+  };
+
+  // 카드 액션 (데모)
+  const handleEdit = (id: string) => alert(`편집: ${id}`);
+  const handleDuplicate = (id: string) => {
+    const g = groups.find(x => x.id === id);
+    if (!g) return;
+    setGroups(prev => [
+      { ...g, id: `copy-${Date.now()}`, name: `${g.name} (복제)` },
+      ...prev,
+    ]);
+  };
+  const handleDelete = (id: string) =>
+    setGroups(prev => prev.filter(g => g.id !== id));
+  const handleManageMembers = (id: string) => alert(`멤버 관리 이동: ${id}`);
+
+  return (
+    <MainLayout activePage="group-management">
+      <div className="space-y-6 p-6">
+        {/* 헤더 + 그룹 추가(모달) */}
+        <div className="flex items-start justify-between">
+          <div>
+            <h1 className="mb-2 text-3xl font-bold text-gray-900">그룹 관리</h1>
+            <p className="text-gray-600">
+              사용자 그룹을 관리하고 권한을 설정하세요
+            </p>
+          </div>
+          <AddGroupDialog onAdd={handleAddGroup} />
+        </div>
+
+        {/* 상단 요약 카드 */}
+        <div className="grid w-full grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-4">
+          <StatCard
+            label="전체 그룹"
+            value={totalGroups}
+            icon={LayoutGrid}
+            valueClassName="text-blue-600"
+          />
+          <StatCard
+            label="전체 멤버"
+            value={totalMembers}
+            icon={Users}
+            valueClassName="text-green-600"
+          />
+          <StatCard
+            label="관리자 그룹"
+            value={adminGroups}
+            icon={Shield}
+            valueClassName="text-rose-600"
+          />
+          <StatCard
+            label="부서 그룹"
+            value={deptGroups}
+            icon={Building2}
+            valueClassName="text-blue-600"
+          />
+        </div>
+
+        {/* 검색 + 필터 */}
+        <SearchFilterBar<GroupFilter>
+          placeholder="그룹명, 설명, 리더로 검색..."
+          query={q}
+          onQueryChange={setQ}
+          filters={GROUP_FILTERS}
+          activeKey={k}
+          onChange={setK}
+        />
+
+        {/* 카드 리스트 */}
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+          {filtered.map(g => (
+            <GroupCard
+              key={g.id}
+              data={g}
+              onEdit={handleEdit}
+              onDelete={handleDelete}
+              onManageMembers={handleManageMembers}
+            />
+          ))}
+        </div>
+      </div>
+    </MainLayout>
+  );
+}

--- a/placeit-frontend/src/components/layout/MainLayout.tsx
+++ b/placeit-frontend/src/components/layout/MainLayout.tsx
@@ -21,7 +21,7 @@ export function MainLayout({
 
       <div className="flex flex-1 overflow-hidden">
         {/* 사이드바 */}
-        <Sidebar activePage={activePage} userName={user.name} />
+        <Sidebar activePage={activePage} userName={user?.name ?? '게스트'} />
 
         {/* 메인 콘텐츠 */}
         <main className="flex-1 overflow-y-auto bg-gray-50">{children}</main>

--- a/placeit-frontend/src/components/layout/Sidebar.tsx
+++ b/placeit-frontend/src/components/layout/Sidebar.tsx
@@ -11,8 +11,11 @@ import {
   Tablet,
   Settings,
   FileText,
+  UserCog,
+  Shield,
 } from 'lucide-react';
 import { useUserStore } from '@/stores/userStore';
+import { usePathname } from 'next/navigation';
 
 interface SidebarProps {
   activePage?: string;
@@ -24,10 +27,11 @@ export function Sidebar({
   userName = '김관리자',
 }: SidebarProps) {
   const { user } = useUserStore();
-  // 현재 날짜 정보
   const currentDate = new Date();
   const currentDay = currentDate.getDate();
   const currentMonth = currentDate.getMonth() + 1;
+  const pathname = usePathname();
+  const normalize = (p: string) => (p.endsWith('/') ? p.slice(0, -1) : p);
 
   const navigationItems = [
     {
@@ -77,7 +81,24 @@ export function Sidebar({
       icon: Users,
       href: '/users',
       badge: '24',
+      subItems: [
+        {
+          id: 'user-management',
+          label: '사용자 관리',
+          subtitle: '개별 사용자 권한 설정',
+          href: '/users', // 목록/개별 사용자 권한 페이지
+          icon: UserCog, // (원하면 Users로 둬도 OK)
+        },
+        {
+          id: 'group-management',
+          label: '그룹 관리',
+          subtitle: '그룹별 권한 관리',
+          href: '/users/groups', // 그룹 관리 페이지
+          icon: Shield, // (원하면 Users로 둬도 OK)
+        },
+      ],
     },
+
     {
       id: 'workspace',
       label: '워크스페이스 관리',
@@ -148,14 +169,8 @@ export function Sidebar({
               {navigationItems.map(item => {
                 const Icon = item.icon;
                 const isActive =
-                  activePage === item.id ||
-                  (item.subItems &&
-                    item.subItems.some(
-                      subItem =>
-                        activePage === subItem.id ||
-                        (activePage === 'reservations' &&
-                          subItem.id === 'reservation-status')
-                    ));
+                  normalize(pathname) === normalize(item.href) ||
+                  pathname.startsWith(`${normalize(item.href)}/`);
 
                 return (
                   <li key={item.id}>
@@ -214,9 +229,7 @@ export function Sidebar({
                         {item.subItems.map(subItem => {
                           const SubIcon = subItem.icon;
                           const isSubActive =
-                            activePage === subItem.id ||
-                            (activePage === 'reservations' &&
-                              subItem.id === 'reservation-status');
+                            normalize(pathname) === normalize(subItem.href);
 
                           return (
                             <li key={subItem.id}>
@@ -327,13 +340,6 @@ export function Sidebar({
               <div className="text-xs text-gray-500">프로필 설정</div>
             </div>
           </Link>
-        </div>
-
-        {/* 하단 N 로고 */}
-        <div className="absolute bottom-4 left-4">
-          <div className="w-10 h-10 bg-gradient-to-br from-gray-800 to-gray-900 rounded-xl flex items-center justify-center shadow-lg hover:shadow-xl transition-all duration-200 cursor-pointer">
-            <span className="text-white font-bold text-lg">N</span>
-          </div>
         </div>
       </div>
     </aside>

--- a/placeit-frontend/src/components/layout/Sidebar.tsx
+++ b/placeit-frontend/src/components/layout/Sidebar.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React from 'react';
 import Link from 'next/link';
 import { Badge } from '@/components/ui/badge';

--- a/placeit-frontend/src/components/management/AddGroupDialog.tsx
+++ b/placeit-frontend/src/components/management/AddGroupDialog.tsx
@@ -1,0 +1,201 @@
+'use client';
+
+import * as React from 'react';
+import * as Dialog from '@radix-ui/react-dialog';
+import { Plus, X } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { Button } from '@/components/ui/button'; // ✅ 네가 사용하는 공통 버튼
+
+export type NewGroup = {
+  name: string;
+  type: 'exec' | 'department' | 'admin';
+  description?: string;
+  leader?: string;
+  maxMembers?: number;
+  createdAt: string; // yyyy-mm-dd
+};
+
+type Props = {
+  onAdd: (g: NewGroup) => void;
+  className?: string;
+};
+
+export default function AddGroupDialog({ onAdd, className }: Props) {
+  const [open, setOpen] = React.useState(false);
+
+  const [form, setForm] = React.useState<NewGroup>({
+    name: '',
+    type: 'department',
+    description: '',
+    leader: '',
+    maxMembers: 0,
+    createdAt: new Date().toISOString().slice(0, 10), // yyyy-mm-dd
+  });
+
+  const handleChange = <K extends keyof NewGroup>(
+    key: K,
+    value: NewGroup[K]
+  ) => {
+    setForm(prev => ({ ...prev, [key]: value }));
+  };
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!form.name.trim()) {
+      alert('그룹명을 입력하세요.');
+      return;
+    }
+    onAdd({
+      ...form,
+      maxMembers: form.maxMembers ? Number(form.maxMembers) : 0,
+    });
+    setOpen(false);
+    // 초기화
+    setForm({
+      name: '',
+      type: 'department',
+      description: '',
+      leader: '',
+      maxMembers: 0,
+      createdAt: new Date().toISOString().slice(0, 10),
+    });
+  };
+
+  return (
+    <Dialog.Root open={open} onOpenChange={setOpen}>
+      <Dialog.Trigger asChild>
+        <Button
+          className={cn('flex items-center gap-2', className)}
+          onClick={() => setOpen(true)}
+        >
+          <Plus className="h-4 w-4" />
+          그룹 추가
+        </Button>
+      </Dialog.Trigger>
+
+      <Dialog.Portal>
+        {/* Overlay */}
+        <Dialog.Overlay className="fixed inset-0 z-40 bg-black/40" />
+        {/* Content */}
+        <Dialog.Content
+          className="fixed left-1/2 top-1/2 z-50 w-[720px] -translate-x-1/2 -translate-y-1/2 rounded-xl bg-white p-6 shadow-xl focus:outline-none"
+          aria-describedby={undefined}
+        >
+          <div className="mb-4 flex items-center justify-between">
+            <Dialog.Title className="text-lg font-semibold text-gray-900">
+              그룹 추가
+            </Dialog.Title>
+            <Dialog.Close asChild>
+              <button
+                className="rounded-md p-1 text-gray-500 hover:bg-gray-100 hover:text-gray-700"
+                aria-label="close"
+              >
+                <X className="h-5 w-5" />
+              </button>
+            </Dialog.Close>
+          </div>
+
+          <form onSubmit={handleSubmit} className="space-y-4">
+            {/* 그룹명 */}
+            <div>
+              <label className="mb-1 block text-sm font-medium text-gray-700">
+                그룹명
+              </label>
+              <input
+                type="text"
+                value={form.name}
+                onChange={e => handleChange('name', e.target.value)}
+                placeholder="예: 플랫폼개발팀"
+                className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm outline-none focus:border-primary-400"
+                required
+              />
+            </div>
+
+            {/* 그룹 타입 */}
+            <div>
+              <label className="mb-1 block text-sm font-medium text-gray-700">
+                그룹 타입
+              </label>
+              <select
+                value={form.type}
+                onChange={e =>
+                  handleChange('type', e.target.value as NewGroup['type'])
+                }
+                className="w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm text-gray-700 outline-none focus:border-primary-400"
+              >
+                <option value="exec">임원진</option>
+                <option value="department">부서</option>
+                <option value="admin">관리자</option>
+              </select>
+            </div>
+
+            {/* 설명 */}
+            <div>
+              <label className="mb-1 block text-sm font-medium text-gray-700">
+                설명
+              </label>
+              <textarea
+                value={form.description}
+                onChange={e => handleChange('description', e.target.value)}
+                rows={3}
+                placeholder="그룹에 대한 간단한 설명을 적어주세요"
+                className="w-full resize-none rounded-md border border-gray-300 px-3 py-2 text-sm outline-none focus:border-primary-400"
+              />
+            </div>
+
+            {/* 리더 */}
+            <div>
+              <label className="mb-1 block text-sm font-medium text-gray-700">
+                리더
+              </label>
+              <input
+                type="text"
+                value={form.leader}
+                onChange={e => handleChange('leader', e.target.value)}
+                placeholder="예: 박수연"
+                className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm outline-none focus:border-primary-400"
+              />
+            </div>
+
+            {/* 최대 멤버수 */}
+            <div>
+              <label className="mb-1 block text-sm font-medium text-gray-700">
+                최대 멤버수
+              </label>
+              <input
+                type="number"
+                min={0}
+                value={Number(form.maxMembers ?? 0)}
+                onChange={e =>
+                  handleChange('maxMembers', Number(e.target.value))
+                }
+                className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm outline-none focus:border-primary-400"
+              />
+            </div>
+
+            {/* 생성일 */}
+            <div>
+              <label className="mb-1 block text-sm font-medium text-gray-700">
+                생성일
+              </label>
+              <input
+                type="date"
+                value={form.createdAt}
+                onChange={e => handleChange('createdAt', e.target.value)}
+                className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm outline-none focus:border-primary-400"
+              />
+            </div>
+
+            {/* Actions */}
+            <div className="mt-6 flex items-center justify-end gap-2">
+              <Dialog.Close asChild>
+                <Button variant="outline">취소</Button>
+              </Dialog.Close>
+              <Button type="submit">추가</Button>
+            </div>
+          </form>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}

--- a/placeit-frontend/src/components/management/GroupCard.tsx
+++ b/placeit-frontend/src/components/management/GroupCard.tsx
@@ -1,0 +1,179 @@
+'use client';
+
+import * as React from 'react';
+import { Crown, Edit3, Trash2, Users, Building2, Shield } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { cn } from '@/lib/utils';
+
+export type GroupType = 'exec' | 'admin' | 'department';
+
+export type GroupCardData = {
+  id: string;
+  name: string;
+  type: GroupType;
+  description?: string;
+  leader?: string;
+  membersCount: number;
+  maxMembers: number;
+  createdAt: string; // ISO
+};
+
+type Props = {
+  data: GroupCardData;
+  className?: string;
+  onEdit?: (id: string) => void;
+  onDelete?: (id: string) => void;
+  onManageMembers?: (id: string) => void;
+};
+
+const TYPE_META = {
+  exec: {
+    label: '임원진',
+    Icon: Crown,
+    iconBg: 'bg-violet-100',
+    iconFg: 'text-violet-600',
+    badge: 'bg-violet-100 text-violet-700 hover:bg-violet-100',
+  },
+  department: {
+    label: '부서',
+    Icon: Building2,
+    iconBg: 'bg-blue-100',
+    iconFg: 'text-blue-600',
+    badge: 'bg-blue-100 text-blue-700 hover:bg-blue-100',
+  },
+  admin: {
+    label: '관리자',
+    Icon: Shield,
+    iconBg: 'bg-rose-100',
+    iconFg: 'text-rose-600',
+    badge: 'bg-rose-100 text-rose-700 hover:bg-rose-100',
+  },
+} as const;
+
+export default function GroupCard({
+  data,
+  className,
+  onEdit,
+  onDelete,
+  onManageMembers,
+}: Props) {
+  const {
+    id,
+    name,
+    type,
+    description,
+    leader,
+    membersCount,
+    maxMembers,
+    createdAt,
+  } = data;
+  const meta = TYPE_META[type];
+
+  const percent =
+    maxMembers > 0
+      ? Math.min(100, Math.round((membersCount / maxMembers) * 100))
+      : 0;
+  const d = new Date(createdAt);
+  const dateStr = `${d.getFullYear()}-${`${d.getMonth() + 1}`.padStart(
+    2,
+    '0'
+  )}-${`${d.getDate()}`.padStart(2, '0')}`;
+
+  return (
+    <div
+      className={cn(
+        'rounded-lg border border-gray-200 bg-white p-4 shadow-sm transition-shadow hover:shadow-md',
+        className
+      )}
+    >
+      {/* 헤더 */}
+      <div className="mb-1.5 flex items-start justify-between">
+        <div className="flex items-start gap-2">
+          <div
+            className={cn(
+              'mt-[2px] flex h-7 w-7 items-center justify-center rounded-full',
+              meta.iconBg
+            )}
+          >
+            <meta.Icon className={cn('h-4 w-4', meta.iconFg)} />
+          </div>
+          <div>
+            <div className="flex items-center gap-2">
+              <h3 className="text-[15px] font-semibold text-gray-900">
+                {name}
+              </h3>
+              <Badge className={meta.badge}>{meta.label}</Badge>
+            </div>
+            {description && (
+              <p className="mt-1 text-[13px] leading-snug text-gray-600">
+                {description}
+              </p>
+            )}
+          </div>
+        </div>
+
+        <div className="flex items-center gap-1">
+          <Button
+            size="icon"
+            variant="ghost"
+            className="h-8 w-8"
+            onClick={() => onEdit?.(id)}
+            title="편집"
+          >
+            <Edit3 className="h-4 w-4" />
+          </Button>
+          <Button
+            size="icon"
+            variant="ghost"
+            className="h-8 w-8 text-red-600 hover:text-red-700"
+            onClick={() => onDelete?.(id)}
+            title="삭제"
+          >
+            <Trash2 className="h-4 w-4" />
+          </Button>
+        </div>
+      </div>
+
+      {/* 메타 정보 */}
+      <div className="grid grid-cols-[auto_1fr] gap-x-3 gap-y-1 text-[13px]">
+        <span className="text-gray-500">리더:</span>
+        <span className="text-gray-800">{leader || '-'}</span>
+
+        <span className="text-gray-500">멤버:</span>
+        <span className="text-gray-800">
+          {membersCount}/{maxMembers}
+        </span>
+
+        <span className="text-gray-500">생성일:</span>
+        <span className="text-gray-800">{dateStr}</span>
+      </div>
+
+      {/* 진행도 */}
+      <div className="mt-3">
+        <div className="mb-1 flex items-center justify-between text-[12px] text-gray-500">
+          <span>멤버 현황</span>
+          <span>{percent}%</span>
+        </div>
+        <div className="h-2 w-full rounded-full bg-gray-200">
+          <div
+            className="h-2 rounded-full bg-blue-600"
+            style={{ width: `${percent}%` }}
+          />
+        </div>
+      </div>
+
+      {/* 액션 버튼 */}
+      <div className="mt-3">
+        <Button
+          variant="secondary"
+          className="w-full justify-center gap-2"
+          onClick={() => onManageMembers?.(id)}
+        >
+          <Users className="h-4 w-4" />
+          멤버 관리
+        </Button>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## 상세내용
- 사용자 관리의 그룹 관리 페이지 퍼블리싱
- 회의실 관리 페이지에서 사용했던 통계 스탯과 검색창 컴포넌트 재활용
- 그룹별 카드 컴포넌트 생성
- 사이드바의 서브 메뉴 생성 및 하이라이트 기능 수정

## 추가해야 할 기능
- 그룹 카드 내용 수정 모달창 및 기능 구현
- 그룹 카드 삭제 기능 구현