### PR TITLE
Feat: 대시보드/예약 페이지 API 연결 및 헤더/사이드바 수정

### DIFF
--- a/placeit-frontend/package-lock.json
+++ b/placeit-frontend/package-lock.json
@@ -14,6 +14,7 @@
         "@radix-ui/react-radio-group": "^1.3.8",
         "@radix-ui/react-separator": "^1.1.7",
         "@radix-ui/react-slot": "^1.2.3",
+        "@radix-ui/react-switch": "^1.2.6",
         "@radix-ui/react-tabs": "^1.1.13",
         "autoprefixer": "^10.4.21",
         "axios": "^1.11.0",
@@ -1408,6 +1409,35 @@
       },
       "peerDependenciesMeta": {
         "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-switch": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-switch/-/react-switch-1.2.6.tgz",
+      "integrity": "sha512-bByzr1+ep1zk4VubeEVViV592vu2lHE2BZY5OnzehZqOOgogN80+mNtCqPkhn2gklJqOpxWgPoYTSnhBCqpOXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-previous": "1.1.1",
+        "@radix-ui/react-use-size": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
           "optional": true
         }
       }

--- a/placeit-frontend/package.json
+++ b/placeit-frontend/package.json
@@ -17,6 +17,7 @@
     "@radix-ui/react-radio-group": "^1.3.8",
     "@radix-ui/react-separator": "^1.1.7",
     "@radix-ui/react-slot": "^1.2.3",
+    "@radix-ui/react-switch": "^1.2.6",
     "@radix-ui/react-tabs": "^1.1.13",
     "autoprefixer": "^10.4.21",
     "axios": "^1.11.0",

--- a/placeit-frontend/src/app/(dashboard)/dashboard/page.tsx
+++ b/placeit-frontend/src/app/(dashboard)/dashboard/page.tsx
@@ -22,6 +22,8 @@ import {
 } from 'lucide-react';
 import { fetchSpaces } from '@/services/spaces';
 import type { Space } from '@/services/spaces';
+import { useWorkspaceStore } from '@/stores/workspaceStore';
+import { api } from '@/lib/axios';
 
 export default function DashboardPage() {
   const router = useRouter();
@@ -37,6 +39,79 @@ export default function DashboardPage() {
   const [currentTime, setCurrentTime] = useState<string>('');
 
   const [spaces, setSpaces] = useState<Space[]>([]);
+
+  const [todayApproved, setTodayApproved] = useState(0);
+  const [weekApproved, setWeekApproved] = useState(0);
+
+  const currentWorkspaceId = useWorkspaceStore(s => s.currentId);
+  const workspaceIdNum =
+    typeof currentWorkspaceId === 'string'
+      ? Number(currentWorkspaceId)
+      : currentWorkspaceId ?? 1; // fallback
+
+  // 가용 슬롯 상태
+  type AvailableRange = { start: Date; end: Date };
+  const [availableRanges, setAvailableRanges] = useState<
+    AvailableRange[] | null
+  >(null);
+
+  // YYYY-MM-DD (로컬 기준) 포맷터
+  const toYMD = (d: Date) => {
+    const y = d.getFullYear();
+    const m = String(d.getMonth() + 1).padStart(2, '0');
+    const da = String(d.getDate()).padStart(2, '0');
+    return `${y}-${m}-${da}`;
+  };
+
+  // 해당 시간(HH:mm)이 가용 범위에 포함되는지 체크
+  const isTimeAvailable = (time: string) => {
+    // 회의실을 선택하지 않았거나 날짜/가용정보가 없으면 모두 활성화
+    if (!selectedRoom || !selectedDate || !availableRanges) return true;
+
+    const [hh, mm] = time.split(':').map(Number);
+    const dt = new Date(selectedDate);
+    dt.setHours(hh, mm, 0, 0);
+
+    // start <= dt < end 에 포함되면 "사용 가능"
+    return availableRanges.some(r => dt >= r.start && dt < r.end);
+  };
+
+  // 사용 가능한 시간 불러오기
+  useEffect(() => {
+    const fetchAvailableTimes = async () => {
+      if (!selectedRoom || !selectedDate) {
+        setAvailableRanges(null); // 회의실이 없거나 날짜가 없으면 전체 활성화
+        return;
+      }
+      try {
+        const dateStr = toYMD(selectedDate);
+        const { data } = await api.get('/reservations/available-times', {
+          params: { spaceId: selectedRoom.id, date: dateStr },
+        });
+
+        const ranges: AvailableRange[] = (data?.availableSlots ?? []).map(
+          (s: { startTime: string; endTime: string }) => ({
+            start: new Date(s.startTime),
+            end: new Date(s.endTime),
+          })
+        );
+        setAvailableRanges(ranges);
+      } catch (e) {
+        console.error('가용 시간 로딩 실패', e);
+        setAvailableRanges(null); // 실패 시라도 전부 활성화(선택 가능)로 둠
+      }
+    };
+
+    fetchAvailableTimes();
+  }, [selectedRoom, selectedDate]);
+
+  useEffect(() => {
+    if (!selectedTime || !selectedRoom || !selectedDate || !availableRanges)
+      return;
+    if (!isTimeAvailable(selectedTime)) {
+      setSelectedTime(''); // 기존 선택 시간이 더이상 불가하면 해제
+    }
+  }, [availableRanges, selectedRoom, selectedDate]);
 
   // 현재 시간 업데이트 (클라이언트 전용)
   useEffect(() => {
@@ -54,15 +129,16 @@ export default function DashboardPage() {
       );
     };
 
-    updateTime(); // 초기 설정
-    const interval = setInterval(updateTime, 1000); // 1초마다 업데이트
-
+    updateTime();
+    const interval = setInterval(updateTime, 1000);
     return () => clearInterval(interval);
   }, []);
 
   // 페이지 로드 시 초기 버튼 상태 설정
   useEffect(() => {
-    const leftArrow = document.getElementById('leftArrow') as HTMLButtonElement;
+    const leftArrow = document.getElementById(
+      'leftArrow'
+    ) as HTMLButtonElement | null;
     if (leftArrow) {
       leftArrow.disabled = true; // 초기에는 왼쪽으로 스크롤할 수 없음
     }
@@ -72,15 +148,78 @@ export default function DashboardPage() {
   useEffect(() => {
     const loadSpaces = async () => {
       try {
-        // workspaceId는 스토어나 라우터 param에서 가져오도록
-        const list = await fetchSpaces(1);
+        if (!workspaceIdNum) return;
+        const list = await fetchSpaces(workspaceIdNum);
         setSpaces(list);
       } catch (e) {
         console.error('회의실 목록 로딩 실패', e);
       }
     };
     loadSpaces();
-  }, []);
+  }, [workspaceIdNum]);
+
+  // 오늘/이번주 확정 예약 계산
+  useEffect(() => {
+    const fetchAndCount = async () => {
+      try {
+        if (!workspaceIdNum) return;
+        const { data } = await api.get(
+          `/workspaces/${workspaceIdNum}/reservations`
+        );
+
+        const list = (data?.reservations ?? []) as Array<{
+          startTime: string;
+          status: string;
+        }>;
+
+        // 승인된 예약만
+        const approved = list.filter(r => r.status === 'APPROVED');
+
+        // 오늘 범위
+        const now = new Date();
+        const todayStart = new Date(now);
+        todayStart.setHours(0, 0, 0, 0);
+        const todayEnd = new Date(now);
+        todayEnd.setHours(23, 59, 59, 999);
+
+        const inRange = (d: Date, start: Date, end: Date) =>
+          d >= start && d <= end;
+
+        const todayCount = approved.filter(r => {
+          const st = new Date(r.startTime);
+          return inRange(st, todayStart, todayEnd);
+        }).length;
+
+        // 이번주 범위 (월~일)
+        const getMonday = (d: Date) => {
+          const day = d.getDay(); // 0:일 ~ 6:토
+          const diff = day === 0 ? -6 : 1 - day; // 월요일로 이동
+          const monday = new Date(d);
+          monday.setDate(d.getDate() + diff);
+          monday.setHours(0, 0, 0, 0);
+          return monday;
+        };
+        const monday = getMonday(now);
+        const sunday = new Date(monday);
+        sunday.setDate(monday.getDate() + 6);
+        sunday.setHours(23, 59, 59, 999);
+
+        const weekCount = approved.filter(r => {
+          const st = new Date(r.startTime);
+          return inRange(st, monday, sunday);
+        }).length;
+
+        setTodayApproved(todayCount);
+        setWeekApproved(weekCount);
+      } catch (e) {
+        console.error('예약 통계 로딩 실패', e);
+        setTodayApproved(0);
+        setWeekApproved(0);
+      }
+    };
+
+    fetchAndCount();
+  }, [workspaceIdNum]);
 
   const handleDateSelect = (date: Date | undefined) => {
     setSelectedDate(date);
@@ -138,7 +277,7 @@ export default function DashboardPage() {
         <div className="grid grid-cols-1 md:grid-cols-2 gap-6 mb-16 mt-8">
           <StatCard
             title="오늘 예약"
-            value="2건"
+            value={`${todayApproved}건`}
             description="일/주/월 뷰로 확인"
             icon={CalendarDays}
             iconColor="text-blue-600"
@@ -148,7 +287,7 @@ export default function DashboardPage() {
           />
           <StatCard
             title="확정된 예약"
-            value="3건"
+            value={`${weekApproved}건`}
             description="이번 주 전체 확정된 예약"
             icon={CheckCircle}
             iconColor="text-green-600"
@@ -193,7 +332,7 @@ export default function DashboardPage() {
                     size="sm"
                     onClick={() => {
                       const slider = document.getElementById('roomSlider');
-                      if (slider) slider.scrollLeft -= 300;
+                      if (slider) (slider as HTMLElement).scrollLeft -= 300;
                     }}
                     className="flex-shrink-0 w-10 h-10 bg-gray-100 hover:bg-gray-200 border border-gray-200 rounded-lg shadow-sm disabled:opacity-50 disabled:cursor-not-allowed"
                     id="leftArrow"
@@ -209,17 +348,14 @@ export default function DashboardPage() {
                       const target = e.target as HTMLElement;
                       const leftArrow = document.getElementById(
                         'leftArrow'
-                      ) as HTMLButtonElement;
+                      ) as HTMLButtonElement | null;
                       const rightArrow = document.getElementById(
                         'rightArrow'
-                      ) as HTMLButtonElement;
+                      ) as HTMLButtonElement | null;
 
-                      // 왼쪽 화살표 활성화/비활성화
-                      if (leftArrow) {
+                      if (leftArrow)
                         leftArrow.disabled = target.scrollLeft <= 0;
-                      }
 
-                      // 오른쪽 화살표 활성화/비활성화
                       if (rightArrow) {
                         const maxScrollLeft =
                           target.scrollWidth - target.clientWidth;
@@ -240,7 +376,8 @@ export default function DashboardPage() {
                           description={space.description}
                           capacity={space.capacity}
                           features={space.amenities}
-                          status="available" // TODO: 실제 상태 값 있으면 매핑
+                          status={space.isActive ? 'available' : 'unavailable'}
+                          requiresApproval={space.requiresApproval}
                           onSelect={() => handleRoomSelect(space)}
                           isSelected={selectedRoom?.id === space.id}
                         />
@@ -254,7 +391,7 @@ export default function DashboardPage() {
                     size="sm"
                     onClick={() => {
                       const slider = document.getElementById('roomSlider');
-                      if (slider) slider.scrollLeft += 300;
+                      if (slider) (slider as HTMLElement).scrollLeft += 300;
                     }}
                     className="flex-shrink-0 w-10 h-10 bg-gray-100 hover:bg-gray-200 border border-gray-200 rounded-lg shadow-sm disabled:opacity-50 disabled:cursor-not-allowed"
                     id="rightArrow"
@@ -290,13 +427,11 @@ export default function DashboardPage() {
                         className="w-full [--cell-size:5rem]"
                         showOutsideDays={false}
                         captionLayout="label"
-                        fromYear={2024}
-                        toYear={2026}
                         reservations={reservations}
                         showDetailedReservations={false}
                         disabled={date => {
                           const today = new Date();
-                          today.setHours(0, 0, 0, 0); // 시/분/초 제거
+                          today.setHours(0, 0, 0, 0);
                           return date < today;
                         }}
                       />
@@ -304,11 +439,7 @@ export default function DashboardPage() {
                   </div>
 
                   <div className="mt-6 text-sm text-gray-600 space-y-2">
-                    <p>
-                      • 당일부터 예약 가능합니다 (오늘: {new Date().getDate()}
-                      일)
-                    </p>
-                    <p>• 날짜를 클릭하면 빠른 예약이 가능합니다</p>
+                    <p>• 당일부터 예약 가능합니다</p>
                   </div>
                 </CardContent>
               </Card>
@@ -331,8 +462,8 @@ export default function DashboardPage() {
                     selectedTime={selectedTime}
                     onTimeSelect={handleTimeSelect}
                     isTimeReserved={time => {
-                      const isReserved = time === '10:00' || time === '10:30';
-                      return isReserved;
+                      if (!selectedRoom) return false; // 회의실 선택 전: 모두 활성화
+                      return !isTimeAvailable(time); // 가용하지 않으면 "예약됨" 처리
                     }}
                     size="large"
                     showLegend={true}

--- a/placeit-frontend/src/app/(dashboard)/reservations/page.tsx
+++ b/placeit-frontend/src/app/(dashboard)/reservations/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useMemo } from 'react';
 import { MainLayout } from '@/components/layout/MainLayout';
 import { Card, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
@@ -14,128 +14,6 @@ import { ChevronLeft, ChevronRight, Users, Filter, Plus } from 'lucide-react';
 import { fetchWorkspaceReservations } from '@/services/reservations';
 import { useActiveWorkspaceId } from '@/lib/workspaceId';
 
-// 샘플 예약 데이터 (2025년 8월 기준)
-const sampleReservations = [
-  {
-    id: '1',
-    title: '주간 팀 미팅',
-    room: '회의실1',
-    date: '2025-08-06',
-    time: '10:00',
-    attendees: ['김태현', '이영희', '박철수'],
-    status: 'confirmed',
-  },
-  {
-    id: '2',
-    title: '프로젝트 회의',
-    room: '소회의실',
-    date: '2025-08-06',
-    time: '14:00',
-    attendees: ['김태현', '최민수'],
-    status: 'confirmed',
-  },
-  {
-    id: '3',
-    title: '월간 전체 회의',
-    room: '대회의실',
-    date: '2025-08-07',
-    time: '09:00',
-    attendees: ['전사원'],
-    status: 'confirmed',
-  },
-  {
-    id: '4',
-    title: '고객 미팅',
-    room: '회의실2',
-    date: '2025-08-08',
-    time: '15:00',
-    attendees: ['김태현', '이영희'],
-    status: 'pending',
-  },
-  {
-    id: '5',
-    title: '제품 기획 회의',
-    room: '소회의실',
-    date: '2025-08-12',
-    time: '11:00',
-    attendees: ['박철수', '최민수'],
-    status: 'confirmed',
-  },
-  // 더 많은 예약 데이터 추가
-  {
-    id: '6',
-    title: '디자인 리뷰',
-    room: '회의실1',
-    date: '2025-08-13',
-    time: '13:00',
-    attendees: ['이영희', '박철수'],
-    status: 'confirmed',
-  },
-  {
-    id: '7',
-    title: '개발 스크럼',
-    room: '소회의실',
-    date: '2025-08-13',
-    time: '15:00',
-    attendees: ['김태현', '최민수'],
-    status: 'confirmed',
-  },
-  {
-    id: '8',
-    title: '마케팅 전략',
-    room: '대회의실',
-    date: '2025-08-14',
-    time: '10:00',
-    attendees: ['전사원'],
-    status: 'confirmed',
-  },
-  {
-    id: '9',
-    title: 'QA 테스트',
-    room: '회의실2',
-    date: '2025-08-14',
-    time: '14:00',
-    attendees: ['박철수'],
-    status: 'pending',
-  },
-  {
-    id: '10',
-    title: '프로젝트 마감',
-    room: '소회의실',
-    date: '2025-08-15',
-    time: '16:00',
-    attendees: ['김태현', '이영희', '박철수'],
-    status: 'confirmed',
-  },
-  {
-    id: '11',
-    title: '신규 기능 기획',
-    room: '회의실1',
-    date: '2025-08-19',
-    time: '11:00',
-    attendees: ['최민수', '박철수'],
-    status: 'confirmed',
-  },
-  {
-    id: '12',
-    title: '사용자 피드백',
-    room: '회의실2',
-    date: '2025-08-19',
-    time: '15:00',
-    attendees: ['이영희'],
-    status: 'pending',
-  },
-  {
-    id: '13',
-    title: '기술 검토',
-    room: '소회의실',
-    date: '2025-08-19',
-    time: '17:00',
-    attendees: ['김태현', '최민수'],
-    status: 'confirmed',
-  },
-];
-
 export default function ReservationsPage() {
   const {
     selectedDate,
@@ -144,6 +22,7 @@ export default function ReservationsPage() {
     setCurrentView,
     reservations,
     addReservation,
+    setReservations,
     error,
     loading,
     clearError,
@@ -172,7 +51,7 @@ export default function ReservationsPage() {
     return h * 60 + m;
   };
 
-  // API의 상태
+  // API의 상태 → UI 상태로 매핑
   const mapStatus = (
     s: 'PENDING' | 'APPROVED' | 'REJECTED'
   ): 'pending' | 'confirmed' | 'cancelled' => {
@@ -181,40 +60,25 @@ export default function ReservationsPage() {
     return 'pending';
   };
 
-  // 컴포넌트 마운트 시 샘플 데이터가 없으면 초기화 (한 번만 실행)
-  useEffect(() => {
-    const initializeSampleData = async () => {
-      if (reservations.length === 0) {
-        // 샘플 데이터를 store에 추가
-        for (const reservation of sampleReservations) {
-          await addReservation({
-            title: reservation.title,
-            room: reservation.room,
-            date: reservation.date,
-            time: reservation.time,
-            attendees: reservation.attendees,
-            status: reservation.status as 'confirmed' | 'pending' | 'cancelled',
-          });
-        }
-      }
-    };
-
-    initializeSampleData();
-  }, [reservations.length, addReservation]); // 의존성 추가
-
-  // 컴포넌트 마운트 시 현재 날짜로 설정
+  // 초기 날짜 설정
   useEffect(() => {
     setSelectedDate(new Date());
   }, [setSelectedDate]);
 
+  // 실제 예약 불러오기 (중복 방지)
   useEffect(() => {
     (async () => {
       try {
-        // 1) 서버에서 전체 예약 불러오기
         if (currentWsId == null) return;
+
         const apiList = await fetchWorkspaceReservations(currentWsId);
 
-        // 2) 페이지 스토어가 기대하는 형태로 변환
+        // 현재 스토어에 있는 (id+date+time) 키
+        const existingKeys = new Set(
+          reservations.map(r => `${r.id ?? ''}-${r.date}-${r.time}`)
+        );
+
+        // API → UI 모델 정규화
         const normalized = apiList.map(r => ({
           id: String(r.id),
           title: r.purpose,
@@ -228,36 +92,26 @@ export default function ReservationsPage() {
                 .map(s => s.trim())
                 .filter(Boolean)
             : [],
-          status: mapStatus(r.status), // 'confirmed' | 'pending' | 'cancelled'
+          status: mapStatus(r.status),
         }));
 
-        // 3) 스토어 초기화
-        for (const r of normalized) {
-          await addReservation(r);
-        }
+        setReservations(normalized);
       } catch (e) {
         console.error('예약 불러오기 실패', e);
       }
     })();
-  }, [currentWsId, addReservation]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [currentWsId]); // addReservation / reservations를 의존성에서 제외해 재추가 방지
 
   const handleDateSelect = (date: Date | undefined) => {
     setSelectedDate(date || null);
-    if (date) {
-      // 날짜를 클릭하면 예약 모달 열기
-      setShowReservationModal(true);
-    }
+    if (date) setShowReservationModal(true);
   };
 
-  const handleNewReservation = () => {
-    setShowReservationModal(true);
-  };
+  const handleNewReservation = () => setShowReservationModal(true);
+  const handleCloseModal = () => setShowReservationModal(false);
 
-  const handleCloseModal = () => {
-    setShowReservationModal(false);
-  };
-
-  // 새로운 예약 추가 함수
+  // 새로운 예약 추가
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const handleAddReservation = async (newReservation: any) => {
     const success = await addReservation({
@@ -270,11 +124,58 @@ export default function ReservationsPage() {
         : [],
       status: 'confirmed' as const,
     });
-
-    if (success) {
-      setShowReservationModal(false);
-    }
+    if (success) setShowReservationModal(false);
   };
+
+  // UI용 '고유' 예약 배열
+  const uniqueReservations = useMemo(() => {
+    const map = new Map<string, (typeof reservations)[number]>();
+    for (const r of reservations) {
+      const k = `${r.id ?? ''}-${r.date}-${r.time}`;
+      if (!map.has(k)) map.set(k, r);
+    }
+    return Array.from(map.values());
+  }, [reservations]);
+
+  // 월 뷰
+  const monthReservations = useMemo(() => {
+    // 날짜별 그룹화
+    const grouped: Record<string, typeof uniqueReservations> = {};
+    for (const r of uniqueReservations) {
+      (grouped[r.date] ??= []).push(r);
+    }
+
+    const result: typeof uniqueReservations = [];
+    const toMin = (t: string) => {
+      const [h, m] = t.split(':').map(Number);
+      return h * 60 + m;
+    };
+
+    for (const date in grouped) {
+      const list = grouped[date]
+        .slice()
+        .sort((a, b) => toMin(a.time) - toMin(b.time));
+      const first = list[0];
+      if (!first) continue;
+
+      // 가장 이른 실제 예약 1건
+      result.push(first);
+
+      // "+N건"
+      if (list.length > 1) {
+        result.push({
+          ...first,
+          id: `${first.id}-extra`,
+          title: `+${list.length - 1}건`,
+          time: '',
+          room: '',
+          status: 'confirmed',
+        });
+      }
+    }
+
+    return result;
+  }, [uniqueReservations]);
 
   return (
     <MainLayout activePage="reservations">
@@ -285,6 +186,7 @@ export default function ReservationsPage() {
             <div className="flex items-center justify-between">
               <div className="flex items-center">
                 <div className="flex-shrink-0">
+                  {/* X 아이콘 */}
                   <svg
                     className="h-5 w-5 text-red-400"
                     viewBox="0 0 20 20"
@@ -339,12 +241,12 @@ export default function ReservationsPage() {
                     r="10"
                     stroke="currentColor"
                     strokeWidth="4"
-                  ></circle>
+                  />
                   <path
                     className="opacity-75"
                     fill="currentColor"
                     d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
-                  ></path>
+                  />
                 </svg>
               </div>
               <div className="ml-3">
@@ -412,7 +314,7 @@ export default function ReservationsPage() {
 
               {/* 날짜 네비게이션 */}
               <div className="flex items-center gap-3 bg-white border border-gray-200 rounded-lg px-4 py-2.5 h-10">
-                {/* 이전 버튼 */}
+                {/* 이전 */}
                 <Button
                   variant="ghost"
                   size="sm"
@@ -433,7 +335,7 @@ export default function ReservationsPage() {
                   <ChevronLeft className="h-4 w-4" />
                 </Button>
 
-                {/* 날짜 표시 */}
+                {/* 표시 */}
                 <div className="flex items-center gap-2 px-3 min-w-[160px] justify-center">
                   {selectedDate instanceof Date && (
                     <>
@@ -473,7 +375,7 @@ export default function ReservationsPage() {
                   )}
                 </div>
 
-                {/* 다음 버튼 */}
+                {/* 다음 */}
                 <Button
                   variant="ghost"
                   size="sm"
@@ -496,7 +398,7 @@ export default function ReservationsPage() {
               </div>
             </div>
 
-            {/* 필터 버튼 */}
+            {/* 필터 버튼 (추후 연결) */}
             <Button
               variant="outline"
               size="sm"
@@ -571,10 +473,11 @@ export default function ReservationsPage() {
                           ).padStart(2, '0')}`
                         : '';
                     const slotMin = toMinutes(time);
-                    const reservation = reservations.find(r => {
+
+                    const reservation = uniqueReservations.find(r => {
                       if (r.date !== selectedDateStr) return false;
                       const start = toMinutes(r.time);
-                      const end = r.endTime ? toMinutes(r.endTime) : start + 30; // endTime 없으면 30분 기본
+                      const end = r.endTime ? toMinutes(r.endTime) : start + 30;
                       return slotMin >= start && slotMin < end;
                     });
 
@@ -593,7 +496,7 @@ export default function ReservationsPage() {
                       isToday && timeInMinutes < currentTimeInMinutes;
                     const isCurrentTime =
                       isToday &&
-                      Math.abs(timeInMinutes - currentTimeInMinutes) <= 15; // 현재 시간 ±15분
+                      Math.abs(timeInMinutes - currentTimeInMinutes) <= 15; // ±15분
 
                     return (
                       <div
@@ -606,9 +509,7 @@ export default function ReservationsPage() {
                             : 'border-gray-200 hover:bg-gray-50'
                         }`}
                         onClick={() => {
-                          if (!isPastTime) {
-                            setShowReservationModal(true);
-                          }
+                          if (!isPastTime) setShowReservationModal(true);
                         }}
                       >
                         <div
@@ -712,7 +613,7 @@ export default function ReservationsPage() {
                 <div className="border border-gray-200 rounded-lg overflow-hidden">
                   {/* 요일 헤더 */}
                   <div className="grid grid-cols-8 bg-gray-50 border-b border-gray-200">
-                    <div className="p-3 border-r border-gray-200 bg-gray-50"></div>
+                    <div className="p-3 border-r border-gray-200 bg-gray-50" />
                     {['일', '월', '화', '수', '목', '금', '토'].map(
                       (day, index) => {
                         const weekStart = new Date(selectedDate || new Date());
@@ -735,12 +636,16 @@ export default function ReservationsPage() {
                           <div
                             key={day}
                             className={`p-3 text-center border-r border-gray-200 last:border-r-0 rounded-md
-        ${isToday ? 'bg-blue-50 text-blue-700 ring-1 ring-blue-200' : ''}
-        ${
-          isPastDay
-            ? 'opacity-50 cursor-not-allowed'
-            : 'cursor-pointer hover:bg-gray-100'
-        }`}
+                            ${
+                              isToday
+                                ? 'bg-blue-50 text-blue-700 ring-1 ring-blue-200'
+                                : ''
+                            }
+                            ${
+                              isPastDay
+                                ? 'opacity-50 cursor-not-allowed'
+                                : 'cursor-pointer hover:bg-gray-100'
+                            }`}
                             onClick={() => {
                               if (!isPastDay) {
                                 setSelectedDate(currentDayDate);
@@ -799,15 +704,16 @@ export default function ReservationsPage() {
                         currentDayDate.getDate()
                       ).padStart(2, '0')}`;
 
-                      const dayReservations = reservations.filter(
+                      const dayReservations = uniqueReservations.filter(
                         r => r.date === currentDayDateStr
                       );
 
                       return (
                         <div
                           key={dayIndex}
-                          className={`border-r border-gray-200 last:border-r-0
-        ${isToday ? 'bg-blue-50/30' : ''} ${
+                          className={`border-r border-gray-200 last:border-r-0 ${
+                            isToday ? 'bg-blue-50/30' : ''
+                          } ${
                             isPastDay ? 'opacity-50 pointer-events-none' : ''
                           }`}
                         >
@@ -830,8 +736,11 @@ export default function ReservationsPage() {
                             return (
                               <div
                                 key={timeIndex}
-                                className={`h-12 border-b border-gray-200 p-1 relative
-              ${isPastDay ? '' : 'cursor-pointer hover:bg-gray-50'}`}
+                                className={`h-12 border-b border-gray-200 p-1 relative ${
+                                  isPastDay
+                                    ? ''
+                                    : 'cursor-pointer hover:bg-gray-50'
+                                }`}
                                 onClick={() => {
                                   if (!isPastDay) {
                                     setSelectedDate(currentDayDate);
@@ -863,7 +772,6 @@ export default function ReservationsPage() {
 
           {/* 월 뷰 */}
           <TabsContent value="month" className="space-y-4 w-full">
-            {/* Calendar */}
             <div className="bg-white border border-gray-200 rounded-lg max-w-4xl mx-auto p-4">
               <div className="[&_.rdp-month_caption]:!hidden [&_.rdp-caption]:!hidden [&_.rdp-caption_label]:!hidden">
                 <Calendar
@@ -873,9 +781,7 @@ export default function ReservationsPage() {
                   className="w-full [--cell-size:4rem]"
                   showOutsideDays={false}
                   captionLayout="label"
-                  fromYear={2024}
-                  toYear={2026}
-                  reservations={reservations}
+                  reservations={monthReservations}
                   showDetailedReservations={true}
                   disabled={date => {
                     const today = new Date();
@@ -906,11 +812,10 @@ export default function ReservationsPage() {
         timeSlots={timeSlots}
         existingReservations={
           selectedDate instanceof Date
-            ? reservations
+            ? uniqueReservations
                 .filter(r => r.date === formatDateToString(selectedDate))
                 .map((r, index) => ({
                   ...r,
-                  // id가 없거나 중복될 경우를 대비해 index 추가
                   id: r.id || `temp-${Date.now()}-${index}`,
                 }))
             : []

--- a/placeit-frontend/src/app/(dashboard)/reservations/page.tsx
+++ b/placeit-frontend/src/app/(dashboard)/reservations/page.tsx
@@ -8,10 +8,11 @@ import { Calendar } from '@/components/ui/calendar';
 import { Tabs, TabsContent } from '@/components/ui/tabs';
 import { ReservationModal } from '@/components/reservation/ReservationModal';
 import { useReservationStore } from '@/stores/reservationStore';
-
 import { formatDateToString } from '@/lib/dateUtils';
 import { timeSlots } from '@/data/sampleData';
 import { ChevronLeft, ChevronRight, Users, Filter, Plus } from 'lucide-react';
+import { fetchWorkspaceReservations } from '@/services/reservations';
+import { useActiveWorkspaceId } from '@/lib/workspaceId';
 
 // 샘플 예약 데이터 (2025년 8월 기준)
 const sampleReservations = [
@@ -149,6 +150,36 @@ export default function ReservationsPage() {
   } = useReservationStore();
 
   const [showReservationModal, setShowReservationModal] = useState(false);
+  const currentWsId = useActiveWorkspaceId();
+
+  const toDateStr = (iso: string) => {
+    const d = new Date(iso);
+    const y = d.getFullYear();
+    const m = String(d.getMonth() + 1).padStart(2, '0');
+    const day = String(d.getDate()).padStart(2, '0');
+    return `${y}-${m}-${day}`;
+  };
+
+  const toTimeHHmm = (iso: string) => {
+    const d = new Date(iso);
+    const H = String(d.getHours()).padStart(2, '0');
+    const M = String(d.getMinutes()).padStart(2, '0');
+    return `${H}:${M}`;
+  };
+
+  const toMinutes = (hhmm: string) => {
+    const [h, m] = hhmm.split(':').map(Number);
+    return h * 60 + m;
+  };
+
+  // API의 상태
+  const mapStatus = (
+    s: 'PENDING' | 'APPROVED' | 'REJECTED'
+  ): 'pending' | 'confirmed' | 'cancelled' => {
+    if (s === 'APPROVED') return 'confirmed';
+    if (s === 'REJECTED') return 'cancelled';
+    return 'pending';
+  };
 
   // 컴포넌트 마운트 시 샘플 데이터가 없으면 초기화 (한 번만 실행)
   useEffect(() => {
@@ -175,6 +206,40 @@ export default function ReservationsPage() {
   useEffect(() => {
     setSelectedDate(new Date());
   }, [setSelectedDate]);
+
+  useEffect(() => {
+    (async () => {
+      try {
+        // 1) 서버에서 전체 예약 불러오기
+        if (currentWsId == null) return;
+        const apiList = await fetchWorkspaceReservations(currentWsId);
+
+        // 2) 페이지 스토어가 기대하는 형태로 변환
+        const normalized = apiList.map(r => ({
+          id: String(r.id),
+          title: r.purpose,
+          room: r.space?.name ?? `공간#${r.spaceId}`,
+          date: toDateStr(r.startTime),
+          time: toTimeHHmm(r.startTime),
+          endTime: toTimeHHmm(r.endTime),
+          attendees: r.attendees
+            ? r.attendees
+                .split(',')
+                .map(s => s.trim())
+                .filter(Boolean)
+            : [],
+          status: mapStatus(r.status), // 'confirmed' | 'pending' | 'cancelled'
+        }));
+
+        // 3) 스토어 초기화
+        for (const r of normalized) {
+          await addReservation(r);
+        }
+      } catch (e) {
+        console.error('예약 불러오기 실패', e);
+      }
+    })();
+  }, [currentWsId, addReservation]);
 
   const handleDateSelect = (date: Date | undefined) => {
     setSelectedDate(date || null);
@@ -505,9 +570,13 @@ export default function ReservationsPage() {
                             selectedDate.getDate()
                           ).padStart(2, '0')}`
                         : '';
-                    const reservation = reservations.find(
-                      r => r.date === selectedDateStr && r.time.startsWith(time)
-                    );
+                    const slotMin = toMinutes(time);
+                    const reservation = reservations.find(r => {
+                      if (r.date !== selectedDateStr) return false;
+                      const start = toMinutes(r.time);
+                      const end = r.endTime ? toMinutes(r.endTime) : start + 30; // endTime 없으면 30분 기본
+                      return slotMin >= start && slotMin < end;
+                    });
 
                     // 현재 시간과 비교하여 비활성화 여부 결정
                     const [hour, minute] = time.split(':').map(Number);
@@ -749,9 +818,14 @@ export default function ReservationsPage() {
                               .toString()
                               .padStart(2, '0')}:${minute}`;
 
-                            const reservation = dayReservations.find(
-                              r => r.time === timeStr
-                            );
+                            const slotMin = toMinutes(timeStr);
+                            const reservation = dayReservations.find(r => {
+                              const start = toMinutes(r.time);
+                              const end = r.endTime
+                                ? toMinutes(r.endTime)
+                                : start + 30;
+                              return slotMin >= start && slotMin < end;
+                            });
 
                             return (
                               <div
@@ -769,9 +843,6 @@ export default function ReservationsPage() {
                                   <div className="absolute inset-1 rounded p-1 text-xs bg-gray-100 text-gray-600">
                                     <div className="font-medium truncate">
                                       {reservation.title}
-                                    </div>
-                                    <div className="text-xs opacity-75">
-                                      {reservation.time}
                                     </div>
                                     <div className="text-xs opacity-75">
                                       {reservation.room}
@@ -807,9 +878,9 @@ export default function ReservationsPage() {
                   reservations={reservations}
                   showDetailedReservations={true}
                   disabled={date => {
-                    // 주말 비활성화
-                    const day = date.getDay();
-                    return day === 0 || day === 6;
+                    const today = new Date();
+                    today.setHours(0, 0, 0, 0);
+                    return date < today;
                   }}
                 />
               </div>

--- a/placeit-frontend/src/app/(dashboard)/reservations/page.tsx
+++ b/placeit-frontend/src/app/(dashboard)/reservations/page.tsx
@@ -6,7 +6,6 @@ import { Card, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Calendar } from '@/components/ui/calendar';
 import { Tabs, TabsContent } from '@/components/ui/tabs';
-import { Switch } from '@/components/ui/switch';
 import { ReservationModal } from '@/components/reservation/ReservationModal';
 import { useReservationStore } from '@/stores/reservationStore';
 import { formatDateToString } from '@/lib/dateUtils';
@@ -14,6 +13,7 @@ import { timeSlots } from '@/data/sampleData';
 import { ChevronLeft, ChevronRight, Users, Filter, Plus } from 'lucide-react';
 import { fetchWorkspaceReservations } from '@/services/reservations';
 import { useActiveWorkspaceId } from '@/lib/workspaceId';
+import { api } from '@/lib/axios';
 
 export default function ReservationsPage() {
   const {
@@ -30,9 +30,19 @@ export default function ReservationsPage() {
   } = useReservationStore();
 
   const [showReservationModal, setShowReservationModal] = useState(false);
-  const [selectedRoom, setSelectedRoom] = useState<string>('');
   const [selectedRoomId, setSelectedRoomId] = useState<string>('');
+  const [modalSelectedTime, setModalSelectedTime] = useState<string>(''); // ← 모달에 보낼 클릭 시각
   const currentWsId = useActiveWorkspaceId();
+
+  // 서버에서 가져오는 공간(회의실) 목록 (capacity 포함)
+  type SpaceLite = {
+    id: number;
+    name: string;
+    description?: string;
+    capacity: number;
+    amenities?: string[];
+  };
+  const [spaces, setSpaces] = useState<SpaceLite[]>([]);
 
   const toDateStr = (iso: string) => {
     const d = new Date(iso);
@@ -68,7 +78,7 @@ export default function ReservationsPage() {
     setSelectedDate(new Date());
   }, [setSelectedDate]);
 
-  // 실제 예약 불러오기 (중복 방지)
+  // 실제 예약 불러오기
   useEffect(() => {
     (async () => {
       try {
@@ -76,18 +86,11 @@ export default function ReservationsPage() {
 
         const apiList = await fetchWorkspaceReservations(currentWsId);
 
-        // 현재 스토어에 있는 (id+date+time) 키
-        const existingKeys = new Set(
-          reservations.map(r => `${r.id ?? ''}-${r.date}-${r.time}`)
-        );
-
-        // API → UI 모델 정규화
         const normalized = apiList.map(r => ({
           id: String(r.id),
           title: r.purpose,
           room: r.space?.name ?? `공간#${r.spaceId}`,
           roomId: String(r.space?.id ?? r.spaceId),
-
           date: toDateStr(r.startTime),
           time: toTimeHHmm(r.startTime),
           endTime: toTimeHHmm(r.endTime),
@@ -106,20 +109,47 @@ export default function ReservationsPage() {
       }
     })();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [currentWsId]); // addReservation / reservations를 의존성에서 제외해 재추가 방지
+  }, [currentWsId]);
+
+  // 워크스페이스 변경 시 공간 목록 로드(수용인원 등)
+  useEffect(() => {
+    (async () => {
+      try {
+        if (currentWsId == null) return;
+        const { data } = await api.get(`/workspaces/${currentWsId}/spaces`);
+        const list = (Array.isArray(data) ? data : data?.spaces ?? []).map(
+          (s: any) => ({
+            id: Number(s.id),
+            name: s.name,
+            description: s.description ?? '',
+            capacity: Number(s.capacity ?? 0),
+            amenities: s.amenities ?? [],
+          })
+        );
+        setSpaces(list);
+      } catch (e) {
+        console.error('공간 목록 조회 실패', e);
+      }
+    })();
+  }, [currentWsId]);
 
   const handleDateSelect = (date: Date | undefined) => {
     setSelectedDate(date || null);
-    if (date) setShowReservationModal(true);
+    if (date) {
+      setModalSelectedTime(''); // 날짜만 선택 시, 시간은 비워둠(모달에서 선택 가능)
+      setShowReservationModal(true);
+    }
   };
 
-  const handleNewReservation = () => setShowReservationModal(true);
+  const handleNewReservation = () => {
+    setModalSelectedTime(''); // “새 예약” 버튼에서는 기본 시간 비움
+    setShowReservationModal(true);
+  };
   const handleCloseModal = () => setShowReservationModal(false);
 
   // 새로운 예약 추가
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const handleAddReservation = async (created: any) => {
-    // 서버 응답(ISO) → UI 표시용 포맷으로 변환
     const dateStr = toDateStr(created.startTime);
     const startHHmm = toTimeHHmm(created.startTime);
     const endHHmm = toTimeHHmm(created.endTime);
@@ -171,41 +201,57 @@ export default function ReservationsPage() {
   const roomOptions = useMemo(() => {
     const idToName = new Map<string, string>();
     for (const r of uniqueReservations) {
-      if (r.roomId) idToName.set(r.roomId, r.room);
+      if ((r as any).roomId) idToName.set((r as any).roomId, r.room);
     }
     return Array.from(idToName, ([id, name]) => ({ id, name })).sort((a, b) =>
       a.name.localeCompare(b.name)
     );
   }, [uniqueReservations]);
 
-  // 공간별 토글/선택에 따른 필터링
+  // 공간별 필터링
   const filteredReservations = useMemo(() => {
     if (!selectedRoomId) return [];
-    return uniqueReservations.filter(r => r.roomId === selectedRoomId);
+    return uniqueReservations.filter((r: any) => r.roomId === selectedRoomId);
   }, [uniqueReservations, selectedRoomId]);
 
+  // 선택된 공간 객체(서버의 capacity 반영)
   const selectedRoomObj = useMemo(() => {
     if (!selectedRoomId) return null;
-    const found = roomOptions.find(r => r.id === selectedRoomId);
-    if (!found) return null;
-    return {
-      id: found.id,
-      name: found.name,
-      description: '',
-      capacity: 0,
-      features: [],
-    };
-  }, [roomOptions, selectedRoomId]);
 
-  // 월 뷰
-  const monthReservations = useMemo(() => {
-    // 날짜별 그룹화
-    const grouped: Record<string, typeof filteredReservations> = {};
-    for (const r of filteredReservations) {
-      (grouped[r.date] ??= []).push(r);
+    const fromSpaces = spaces.find(
+      s => String(s.id) === String(selectedRoomId)
+    );
+    if (fromSpaces) {
+      return {
+        id: fromSpaces.id,
+        name: fromSpaces.name,
+        description: fromSpaces.description ?? '',
+        capacity: fromSpaces.capacity ?? 0,
+        features: fromSpaces.amenities ?? [],
+      };
     }
 
-    const result: typeof uniqueReservations = [];
+    const found = roomOptions.find(r => r.id === selectedRoomId);
+    if (found) {
+      return {
+        id: found.id,
+        name: found.name,
+        description: '',
+        capacity: 0,
+        features: [],
+      };
+    }
+    return null;
+  }, [selectedRoomId, spaces, roomOptions]);
+
+  // 월 뷰 집계(+N건)
+  const monthReservations = useMemo(() => {
+    const grouped: Record<string, typeof filteredReservations> = {};
+    for (const r of filteredReservations) {
+      (grouped[(r as any).date] ??= []).push(r as any);
+    }
+
+    const result: any[] = [];
     const toMin = (t: string) => {
       const [h, m] = t.split(':').map(Number);
       return h * 60 + m;
@@ -214,18 +260,16 @@ export default function ReservationsPage() {
     for (const date in grouped) {
       const list = grouped[date]
         .slice()
-        .sort((a, b) => toMin(a.time) - toMin(b.time));
+        .sort((a, b) => toMin((a as any).time) - toMin((b as any).time));
       const first = list[0];
       if (!first) continue;
 
-      // 가장 이른 실제 예약 1건
       result.push(first);
 
-      // "+N건"
       if (list.length > 1) {
         result.push({
           ...first,
-          id: `${first.id}-extra`,
+          id: `${(first as any).id}-extra`,
           title: `+${list.length - 1}건`,
           time: '',
           room: '',
@@ -342,7 +386,7 @@ export default function ReservationsPage() {
               ))}
             </select>
 
-            {/* 새 예약 버튼은 그대로 유지 */}
+            {/* 새 예약 */}
             <Button
               onClick={handleNewReservation}
               className="bg-blue-600 hover:bg-blue-700 shadow-lg shadow-blue-200"
@@ -552,12 +596,16 @@ export default function ReservationsPage() {
                         : '';
                     const slotMin = toMinutes(time);
 
-                    const reservation = filteredReservations.find(r => {
-                      if (r.date !== selectedDateStr) return false;
-                      const start = toMinutes(r.time);
-                      const end = r.endTime ? toMinutes(r.endTime) : start + 30;
-                      return slotMin >= start && slotMin < end;
-                    });
+                    const reservation = (filteredReservations as any[]).find(
+                      r => {
+                        if (r.date !== selectedDateStr) return false;
+                        const start = toMinutes(r.time);
+                        const end = r.endTime
+                          ? toMinutes(r.endTime)
+                          : start + 30;
+                        return slotMin >= start && slotMin < end;
+                      }
+                    );
 
                     // 현재 시간과 비교하여 비활성화 여부 결정
                     const [hour, minute] = time.split(':').map(Number);
@@ -587,7 +635,10 @@ export default function ReservationsPage() {
                             : 'border-gray-200 hover:bg-gray-50'
                         }`}
                         onClick={() => {
-                          if (!isPastTime) setShowReservationModal(true);
+                          if (!isPastTime) {
+                            setModalSelectedTime(time); // ← 클릭한 시간 저장
+                            setShowReservationModal(true);
+                          }
                         }}
                       >
                         <div
@@ -701,7 +752,6 @@ export default function ReservationsPage() {
                         const currentDayDate = new Date(weekStart);
                         currentDayDate.setDate(weekStart.getDate() + index);
 
-                        // 오늘 00:00 기준
                         const today = new Date();
                         today.setHours(0, 0, 0, 0);
                         const dayStart = new Date(currentDayDate);
@@ -727,6 +777,7 @@ export default function ReservationsPage() {
                             onClick={() => {
                               if (!isPastDay) {
                                 setSelectedDate(currentDayDate);
+                                setModalSelectedTime(''); // 요일만 클릭 시 시간 비움
                                 setShowReservationModal(true);
                               }
                             }}
@@ -782,9 +833,9 @@ export default function ReservationsPage() {
                         currentDayDate.getDate()
                       ).padStart(2, '0')}`;
 
-                      const dayReservations = filteredReservations.filter(
-                        r => r.date === currentDayDateStr
-                      );
+                      const dayReservations = (
+                        filteredReservations as any[]
+                      ).filter(r => r.date === currentDayDateStr);
 
                       return (
                         <div
@@ -804,9 +855,9 @@ export default function ReservationsPage() {
 
                             const slotMin = toMinutes(timeStr);
                             const reservation = dayReservations.find(r => {
-                              const start = toMinutes(r.time);
-                              const end = r.endTime
-                                ? toMinutes(r.endTime)
+                              const start = toMinutes((r as any).time);
+                              const end = (r as any).endTime
+                                ? toMinutes((r as any).endTime)
                                 : start + 30;
                               return slotMin >= start && slotMin < end;
                             });
@@ -822,6 +873,7 @@ export default function ReservationsPage() {
                                 onClick={() => {
                                   if (!isPastDay) {
                                     setSelectedDate(currentDayDate);
+                                    setModalSelectedTime(timeStr); // ← 셀 클릭 시각 저장
                                     setShowReservationModal(true);
                                   }
                                 }}
@@ -829,10 +881,10 @@ export default function ReservationsPage() {
                                 {reservation && (
                                   <div className="absolute inset-1 rounded p-1 text-xs bg-gray-100 text-gray-600">
                                     <div className="font-medium truncate">
-                                      {reservation.title}
+                                      {(reservation as any).title}
                                     </div>
                                     <div className="text-xs opacity-75">
-                                      {reservation.room}
+                                      {(reservation as any).room}
                                     </div>
                                   </div>
                                 )}
@@ -859,7 +911,7 @@ export default function ReservationsPage() {
                   className="w-full [--cell-size:4rem]"
                   showOutsideDays={false}
                   captionLayout="label"
-                  reservations={monthReservations}
+                  reservations={monthReservations as any}
                   showDetailedReservations={true}
                   disabled={date => {
                     const today = new Date();
@@ -880,15 +932,15 @@ export default function ReservationsPage() {
         onAddReservation={handleAddReservation}
         room={selectedRoomObj}
         selectedDate={selectedDate || undefined}
-        selectedTime="10:00"
+        selectedTime={modalSelectedTime} // ← 클릭된 시간 전달
         timeSlots={timeSlots}
         existingReservations={
           selectedDate instanceof Date
-            ? filteredReservations
+            ? (filteredReservations as any[])
                 .filter(r => r.date === formatDateToString(selectedDate))
                 .map((r, index) => ({
                   ...r,
-                  id: r.id || `temp-${Date.now()}-${index}`,
+                  id: (r as any).id || `temp-${Date.now()}-${index}`,
                 }))
             : []
         }

--- a/placeit-frontend/src/app/(dashboard)/reservations/page.tsx
+++ b/placeit-frontend/src/app/(dashboard)/reservations/page.tsx
@@ -8,6 +8,7 @@ import { Calendar } from '@/components/ui/calendar';
 import { Tabs, TabsContent } from '@/components/ui/tabs';
 import { ReservationModal } from '@/components/reservation/ReservationModal';
 import { useReservationStore } from '@/stores/reservationStore';
+import { useUserStore } from '@/stores/userStore';
 import { formatDateToString } from '@/lib/dateUtils';
 import { timeSlots } from '@/data/sampleData';
 import {
@@ -36,6 +37,8 @@ export default function ReservationsPage() {
     loading,
     clearError,
   } = useReservationStore();
+
+  const myUserId = useUserStore(s => s.user?.id);
 
   const [showReservationModal, setShowReservationModal] = useState(false);
   const [selectedRoomId, setSelectedRoomId] = useState<string>('');
@@ -77,11 +80,12 @@ export default function ReservationsPage() {
 
   // API의 상태 → UI 상태로 매핑
   const mapStatus = (
-    s: 'PENDING' | 'APPROVED' | 'REJECTED'
-  ): 'pending' | 'confirmed' | 'cancelled' => {
-    if (s === 'APPROVED') return 'confirmed';
-    if (s === 'REJECTED') return 'cancelled';
-    return 'pending';
+    s: 'PENDING' | 'APPROVED' | 'REJECTED' | 'COMPLETED'
+  ): 'pending' | 'confirmed' | 'cancelled' | 'hidden' => {
+    if (s === 'APPROVED' || s === 'COMPLETED') return 'confirmed';
+    if (s === 'PENDING') return 'pending';
+    if (s === 'REJECTED') return 'hidden'; // 숨기기
+    return 'hidden'; // 그 외 알 수 없는 값도 숨김 처리
   };
 
   // 09:00 ~ 17:30 타임라인에서 상대 위치 계산
@@ -142,6 +146,7 @@ export default function ReservationsPage() {
                 .filter(Boolean)
             : [],
           status: mapStatus(r.status),
+          ownerId: r.userId ?? r.user?.id ?? null,
         }));
 
         setReservations(normalized);
@@ -766,74 +771,88 @@ export default function ReservationsPage() {
                           ).filter(r => r.date === selectedDateStr);
 
                           return dayReservations.map((r, idx) => {
+                            if ((r as any).status === 'hidden') return null; // 숨김 처리
+
                             const { top, height } = toBlockStyle(
                               (r as any).time,
                               (r as any).endTime
                             );
+
+                            const baseClasses =
+                              'group absolute left-2 right-2 rounded-md shadow-sm p-2 text-xs overflow-hidden';
+
+                            const colorClasses =
+                              (r as any).status === 'confirmed'
+                                ? 'border-l-4 border-blue-500 bg-blue-50'
+                                : 'border-l-4 border-gray-400 bg-gray-100';
+
                             return (
                               <div
                                 key={`${(r as any).id}-${idx}`}
-                                className="group absolute left-2 right-2 rounded-md border-l-4 border-blue-500 bg-blue-50 shadow-sm p-2 text-xs overflow-hidden"
+                                className={`${baseClasses} ${colorClasses}`}
                                 style={{ top, height }}
                                 title={`${(r as any).time} ~ ${
                                   (r as any).endTime || ''
                                 }`}
                               >
                                 {/* 액션 버튼 */}
-                                <div className="absolute top-1 right-1 z-10 flex gap-1 opacity-100 sm:opacity-0 sm:group-hover:opacity-100 transition-opacity">
-                                  <Button
-                                    size="icon"
-                                    variant="ghost"
-                                    className="h-6 w-6 rounded-md text-gray-700 hover:bg-blue-100 hover:text-blue-700"
-                                    aria-label="예약 수정"
-                                    onClick={e => {
-                                      e.stopPropagation();
-                                      handleEditClick(r);
-                                    }}
-                                  >
-                                    <Pencil className="h-3.5 w-3.5" />
-                                  </Button>
-                                  <Button
-                                    size="icon"
-                                    variant="ghost"
-                                    className="h-6 w-6 rounded-md text-gray-700 hover:bg-rose-100 hover:text-rose-700 disabled:opacity-50"
-                                    aria-label="예약 삭제"
-                                    disabled={
-                                      deletingId === String((r as any).id)
-                                    }
-                                    onClick={e => {
-                                      e.stopPropagation();
-                                      handleDeleteClick(r);
-                                    }}
-                                  >
-                                    {deletingId === String((r as any).id) ? (
-                                      <svg
-                                        className="h-3.5 w-3.5 animate-spin"
-                                        viewBox="0 0 24 24"
-                                      >
-                                        <circle
-                                          cx="12"
-                                          cy="12"
-                                          r="10"
-                                          stroke="currentColor"
-                                          strokeWidth="3"
-                                          fill="none"
-                                          className="opacity-30"
-                                        />
-                                        <path
-                                          d="M12 2a10 10 0 0 1 10 10"
-                                          stroke="currentColor"
-                                          strokeWidth="3"
-                                          fill="none"
-                                        />
-                                      </svg>
-                                    ) : (
-                                      <Trash2 className="h-3.5 w-3.5" />
-                                    )}
-                                  </Button>
-                                </div>
+                                {String((r as any).ownerId ?? '') ===
+                                  String(myUserId ?? '') && (
+                                  <div className="absolute top-1 right-1 z-10 flex gap-1 opacity-100 sm:opacity-0 sm:group-hover:opacity-100 transition-opacity">
+                                    <Button
+                                      size="icon"
+                                      variant="ghost"
+                                      className="h-6 w-6 rounded-md text-gray-700 hover:bg-blue-100 hover:text-blue-700"
+                                      aria-label="예약 수정"
+                                      onClick={e => {
+                                        e.stopPropagation();
+                                        handleEditClick(r);
+                                      }}
+                                    >
+                                      <Pencil className="h-3.5 w-3.5" />
+                                    </Button>
+                                    <Button
+                                      size="icon"
+                                      variant="ghost"
+                                      className="h-6 w-6 rounded-md text-gray-700 hover:bg-rose-100 hover:text-rose-700 disabled:opacity-50"
+                                      aria-label="예약 삭제"
+                                      disabled={
+                                        deletingId === String((r as any).id)
+                                      }
+                                      onClick={e => {
+                                        e.stopPropagation();
+                                        handleDeleteClick(r);
+                                      }}
+                                    >
+                                      {deletingId === String((r as any).id) ? (
+                                        <svg
+                                          className="h-3.5 w-3.5 animate-spin"
+                                          viewBox="0 0 24 24"
+                                        >
+                                          <circle
+                                            cx="12"
+                                            cy="12"
+                                            r="10"
+                                            stroke="currentColor"
+                                            strokeWidth="3"
+                                            fill="none"
+                                            className="opacity-30"
+                                          />
+                                          <path
+                                            d="M12 2a10 10 0 0 1 10 10"
+                                            stroke="currentColor"
+                                            strokeWidth="3"
+                                            fill="none"
+                                          />
+                                        </svg>
+                                      ) : (
+                                        <Trash2 className="h-3.5 w-3.5" />
+                                      )}
+                                    </Button>
+                                  </div>
+                                )}
 
-                                <div className="font-semibold truncate">
+                                <div className="font-semibold text-sm truncate">
                                   {(r as any).title}
                                 </div>
                                 <div className="text-[11px] text-gray-600 truncate">
@@ -842,6 +861,12 @@ export default function ReservationsPage() {
                                     ? ` - ${(r as any).endTime}`
                                     : ''}
                                 </div>
+                                {Array.isArray((r as any).attendees) &&
+                                  (r as any).attendees.length > 0 && (
+                                    <div className="text-[11px] text-gray-500 truncate mt-1">
+                                      참석자: {(r as any).attendees.join(', ')}
+                                    </div>
+                                  )}
                               </div>
                             );
                           });
@@ -1062,72 +1087,87 @@ export default function ReservationsPage() {
                           {/* 예약 블록들 */}
                           <div className="absolute inset-0 z-20">
                             {dayReservations.map((r, idx) => {
+                              if ((r as any).status === 'hidden') return null; // 숨김 처리
+
                               const { top, height } = toBlockStyle(
                                 (r as any).time,
                                 (r as any).endTime
                               );
+
+                              const baseClasses =
+                                'group absolute left-2 right-2 rounded-md shadow-sm p-2 text-xs overflow-hidden';
+
+                              const colorClasses =
+                                (r as any).status === 'confirmed'
+                                  ? 'border-l-4 border-blue-500 bg-blue-50'
+                                  : 'border-l-4 border-gray-400 bg-gray-100';
+
                               return (
                                 <div
                                   key={`${(r as any).id}-${idx}`}
-                                  className="group absolute left-1 right-1 rounded-md border-l-4 border-blue-500 bg-blue-50 shadow-sm p-2 text-xs overflow-hidden"
+                                  className={`${baseClasses} ${colorClasses}`}
                                   style={{ top, height }}
                                   title={`${(r as any).time} ~ ${
                                     (r as any).endTime || ''
                                   }`}
                                 >
                                   {/* 액션 버튼 */}
-                                  <div className="absolute top-1 right-1 z-10 flex gap-1 opacity-100 sm:opacity-0 sm:group-hover:opacity-100 transition-opacity">
-                                    <Button
-                                      size="icon"
-                                      variant="ghost"
-                                      className="h-6 w-6 rounded-md text-gray-700 hover:bg-blue-100 hover:text-blue-700"
-                                      aria-label="예약 수정"
-                                      onClick={e => {
-                                        e.stopPropagation();
-                                        handleEditClick(r);
-                                      }}
-                                    >
-                                      <Pencil className="h-3.5 w-3.5" />
-                                    </Button>
-                                    <Button
-                                      size="icon"
-                                      variant="ghost"
-                                      className="h-6 w-6 rounded-md text-gray-700 hover:bg-rose-100 hover:text-rose-700 disabled:opacity-50"
-                                      aria-label="예약 삭제"
-                                      disabled={
-                                        deletingId === String((r as any).id)
-                                      }
-                                      onClick={e => {
-                                        e.stopPropagation();
-                                        handleDeleteClick(r);
-                                      }}
-                                    >
-                                      {deletingId === String((r as any).id) ? (
-                                        <svg
-                                          className="h-3.5 w-3.5 animate-spin"
-                                          viewBox="0 0 24 24"
-                                        >
-                                          <circle
-                                            cx="12"
-                                            cy="12"
-                                            r="10"
-                                            stroke="currentColor"
-                                            strokeWidth="3"
-                                            fill="none"
-                                            className="opacity-30"
-                                          />
-                                          <path
-                                            d="M12 2a10 10 0 0 1 10 10"
-                                            stroke="currentColor"
-                                            strokeWidth="3"
-                                            fill="none"
-                                          />
-                                        </svg>
-                                      ) : (
-                                        <Trash2 className="h-3.5 w-3.5" />
-                                      )}
-                                    </Button>
-                                  </div>
+                                  {String((r as any).ownerId ?? '') ===
+                                    String(myUserId ?? '') && (
+                                    <div className="absolute top-1 right-1 z-10 flex gap-1 opacity-100 sm:opacity-0 sm:group-hover:opacity-100 transition-opacity">
+                                      <Button
+                                        size="icon"
+                                        variant="ghost"
+                                        className="h-6 w-6 rounded-md text-gray-700 hover:bg-blue-100 hover:text-blue-700"
+                                        aria-label="예약 수정"
+                                        onClick={e => {
+                                          e.stopPropagation();
+                                          handleEditClick(r);
+                                        }}
+                                      >
+                                        <Pencil className="h-3.5 w-3.5" />
+                                      </Button>
+                                      <Button
+                                        size="icon"
+                                        variant="ghost"
+                                        className="h-6 w-6 rounded-md text-gray-700 hover:bg-rose-100 hover:text-rose-700 disabled:opacity-50"
+                                        aria-label="예약 삭제"
+                                        disabled={
+                                          deletingId === String((r as any).id)
+                                        }
+                                        onClick={e => {
+                                          e.stopPropagation();
+                                          handleDeleteClick(r);
+                                        }}
+                                      >
+                                        {deletingId ===
+                                        String((r as any).id) ? (
+                                          <svg
+                                            className="h-3.5 w-3.5 animate-spin"
+                                            viewBox="0 0 24 24"
+                                          >
+                                            <circle
+                                              cx="12"
+                                              cy="12"
+                                              r="10"
+                                              stroke="currentColor"
+                                              strokeWidth="3"
+                                              fill="none"
+                                              className="opacity-30"
+                                            />
+                                            <path
+                                              d="M12 2a10 10 0 0 1 10 10"
+                                              stroke="currentColor"
+                                              strokeWidth="3"
+                                              fill="none"
+                                            />
+                                          </svg>
+                                        ) : (
+                                          <Trash2 className="h-3.5 w-3.5" />
+                                        )}
+                                      </Button>
+                                    </div>
+                                  )}
 
                                   <div className="font-semibold text-sm truncate">
                                     {(r as any).title}

--- a/placeit-frontend/src/app/(dashboard)/reservations/page.tsx
+++ b/placeit-frontend/src/app/(dashboard)/reservations/page.tsx
@@ -6,6 +6,7 @@ import { Card, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Calendar } from '@/components/ui/calendar';
 import { Tabs, TabsContent } from '@/components/ui/tabs';
+import { Switch } from '@/components/ui/switch';
 import { ReservationModal } from '@/components/reservation/ReservationModal';
 import { useReservationStore } from '@/stores/reservationStore';
 import { formatDateToString } from '@/lib/dateUtils';
@@ -29,6 +30,7 @@ export default function ReservationsPage() {
   } = useReservationStore();
 
   const [showReservationModal, setShowReservationModal] = useState(false);
+  const [selectedRoom, setSelectedRoom] = useState<string>('');
   const currentWsId = useActiveWorkspaceId();
 
   const toDateStr = (iso: string) => {
@@ -137,11 +139,21 @@ export default function ReservationsPage() {
     return Array.from(map.values());
   }, [reservations]);
 
+  // 방 이름 옵션
+  const roomOptions = useMemo(() => {
+    return Array.from(new Set(uniqueReservations.map(r => r.room))).sort();
+  }, [uniqueReservations]);
+
+  // 공간별 토글/선택에 따른 필터링
+  const filteredReservations = useMemo(() => {
+    if (!selectedRoom) return []; // 아무 것도 선택 안 하면 빈 목록
+    return uniqueReservations.filter(r => r.room === selectedRoom);
+  }, [uniqueReservations, selectedRoom]);
   // 월 뷰
   const monthReservations = useMemo(() => {
     // 날짜별 그룹화
-    const grouped: Record<string, typeof uniqueReservations> = {};
-    for (const r of uniqueReservations) {
+    const grouped: Record<string, typeof filteredReservations> = {};
+    for (const r of filteredReservations) {
       (grouped[r.date] ??= []).push(r);
     }
 
@@ -175,11 +187,11 @@ export default function ReservationsPage() {
     }
 
     return result;
-  }, [uniqueReservations]);
+  }, [filteredReservations]);
 
   return (
     <MainLayout activePage="reservations">
-      <div className="p-4 space-y-6 mx-auto">
+      <div className="p-6 space-y-8 mx-auto">
         {/* 에러 메시지 */}
         {error && (
           <div className="bg-red-50 border border-red-200 rounded-lg p-4">
@@ -263,15 +275,33 @@ export default function ReservationsPage() {
               예약 현황
             </h1>
             <p className="text-gray-600 mt-2">
-              공간별 예약 현황을 확인하고 관리하세요
+              선택한 공간의 예약 현황을 확인하세요
             </p>
           </div>
-          <Button
-            onClick={handleNewReservation}
-            className="bg-blue-600 hover:bg-blue-700 shadow-lg shadow-blue-200"
-          >
-            <Plus className="h-4 w-4 mr-2" />새 예약
-          </Button>
+
+          <div className="flex items-center gap-3">
+            {/* 공간 선택 */}
+            <select
+              value={selectedRoom}
+              onChange={e => setSelectedRoom(e.target.value)}
+              className="h-10 pl-3 pr-8 border border-gray-200 rounded-lg text-sm text-gray-700 bg-white shadow-sm"
+            >
+              <option value="">공간 선택…</option>
+              {roomOptions.map(room => (
+                <option key={room} value={room}>
+                  {room}
+                </option>
+              ))}
+            </select>
+
+            {/* 새 예약 버튼은 그대로 유지 */}
+            <Button
+              onClick={handleNewReservation}
+              className="bg-blue-600 hover:bg-blue-700 shadow-lg shadow-blue-200"
+            >
+              <Plus className="h-4 w-4 mr-2" />새 예약
+            </Button>
+          </div>
         </div>
 
         {/* 뷰 선택 및 네비게이션 */}
@@ -474,7 +504,7 @@ export default function ReservationsPage() {
                         : '';
                     const slotMin = toMinutes(time);
 
-                    const reservation = uniqueReservations.find(r => {
+                    const reservation = filteredReservations.find(r => {
                       if (r.date !== selectedDateStr) return false;
                       const start = toMinutes(r.time);
                       const end = r.endTime ? toMinutes(r.endTime) : start + 30;
@@ -704,7 +734,7 @@ export default function ReservationsPage() {
                         currentDayDate.getDate()
                       ).padStart(2, '0')}`;
 
-                      const dayReservations = uniqueReservations.filter(
+                      const dayReservations = filteredReservations.filter(
                         r => r.date === currentDayDateStr
                       );
 
@@ -812,7 +842,7 @@ export default function ReservationsPage() {
         timeSlots={timeSlots}
         existingReservations={
           selectedDate instanceof Date
-            ? uniqueReservations
+            ? filteredReservations
                 .filter(r => r.date === formatDateToString(selectedDate))
                 .map((r, index) => ({
                   ...r,

--- a/placeit-frontend/src/app/(dashboard)/reservations/page.tsx
+++ b/placeit-frontend/src/app/(dashboard)/reservations/page.tsx
@@ -10,7 +10,7 @@ import { ReservationModal } from '@/components/reservation/ReservationModal';
 import { useReservationStore } from '@/stores/reservationStore';
 import { formatDateToString } from '@/lib/dateUtils';
 import { timeSlots } from '@/data/sampleData';
-import { ChevronLeft, ChevronRight, Users, Filter, Plus } from 'lucide-react';
+import { ChevronLeft, ChevronRight, Users, Filter, Check } from 'lucide-react';
 import { fetchWorkspaceReservations } from '@/services/reservations';
 import { useActiveWorkspaceId } from '@/lib/workspaceId';
 import { api } from '@/lib/axios';
@@ -31,8 +31,11 @@ export default function ReservationsPage() {
 
   const [showReservationModal, setShowReservationModal] = useState(false);
   const [selectedRoomId, setSelectedRoomId] = useState<string>('');
-  const [modalSelectedTime, setModalSelectedTime] = useState<string>(''); // ← 모달에 보낼 클릭 시각
+  const [modalSelectedTime, setModalSelectedTime] = useState<string>('');
   const currentWsId = useActiveWorkspaceId();
+
+  // ✅ 새로 추가: "내 예약만 보기" 토글 상태
+  const [myOnly, setMyOnly] = useState<boolean>(false);
 
   // 서버에서 가져오는 공간(회의실) 목록 (capacity 포함)
   type SpaceLite = {
@@ -78,13 +81,31 @@ export default function ReservationsPage() {
     setSelectedDate(new Date());
   }, [setSelectedDate]);
 
-  // 실제 예약 불러오기
+  // ✅ 예약 불러오기: 워크스페이스 전체 vs 내 예약만
   useEffect(() => {
     (async () => {
       try {
         if (currentWsId == null) return;
 
-        const apiList = await fetchWorkspaceReservations(currentWsId);
+        let apiList: any[] = [];
+
+        if (myOnly) {
+          // 내 예약만
+          const { data } = await api.get('/reservations/my');
+          const list = Array.isArray(data) ? data : data?.reservations ?? [];
+          // 현재 워크스페이스에 속한 예약만 남김 (space.workspaceId 또는 space.workspace.id 중 있는 값 사용)
+          const wsIdNum = Number(currentWsId);
+          apiList = list.filter((r: any) => {
+            const s = r.space ?? {};
+            const wid = Number(
+              s.workspaceId ?? s.workspace?.id ?? r.workspaceId ?? NaN
+            );
+            return Number.isFinite(wid) ? wid === wsIdNum : true; // 공간 정보가 없으면 보수적으로 포함
+          });
+        } else {
+          // 워크스페이스 전체
+          apiList = await fetchWorkspaceReservations(currentWsId);
+        }
 
         const normalized = apiList.map(r => ({
           id: String(r.id),
@@ -97,7 +118,7 @@ export default function ReservationsPage() {
           attendees: r.attendees
             ? r.attendees
                 .split(',')
-                .map(s => s.trim())
+                .map((s: string) => s.trim())
                 .filter(Boolean)
             : [],
           status: mapStatus(r.status),
@@ -109,7 +130,7 @@ export default function ReservationsPage() {
       }
     })();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [currentWsId]);
+  }, [currentWsId, myOnly]);
 
   // 워크스페이스 변경 시 공간 목록 로드(수용인원 등)
   useEffect(() => {
@@ -136,19 +157,18 @@ export default function ReservationsPage() {
   const handleDateSelect = (date: Date | undefined) => {
     setSelectedDate(date || null);
     if (date) {
-      setModalSelectedTime(''); // 날짜만 선택 시, 시간은 비워둠(모달에서 선택 가능)
+      setModalSelectedTime('');
       setShowReservationModal(true);
     }
   };
 
   const handleNewReservation = () => {
-    setModalSelectedTime(''); // “새 예약” 버튼에서는 기본 시간 비움
+    setModalSelectedTime('');
     setShowReservationModal(true);
   };
   const handleCloseModal = () => setShowReservationModal(false);
 
   // 새로운 예약 추가
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const handleAddReservation = async (created: any) => {
     const dateStr = toDateStr(created.startTime);
     const startHHmm = toTimeHHmm(created.startTime);
@@ -158,8 +178,7 @@ export default function ReservationsPage() {
       created?.space?.name ?? `공간#${created.spaceId ?? '알수없음'}`;
 
     const attendees =
-      typeof created.attendees === 'string' &&
-      created.attendees.trim().length > 0
+      typeof created.attendees === 'string' && created.attendees.trim()
         ? created.attendees
             .split(',')
             .map((s: string) => s.trim())
@@ -207,6 +226,13 @@ export default function ReservationsPage() {
       a.name.localeCompare(b.name)
     );
   }, [uniqueReservations]);
+
+  // 예약/옵션이 로드된 뒤, 처음 한 번 기본 회의실 자동 선택
+  useEffect(() => {
+    if (!selectedRoomId && roomOptions.length > 0) {
+      setSelectedRoomId(roomOptions[0].id); // 이름순 첫 번째
+    }
+  }, [roomOptions, selectedRoomId]);
 
   // 공간별 필터링
   const filteredReservations = useMemo(() => {
@@ -391,7 +417,7 @@ export default function ReservationsPage() {
               onClick={handleNewReservation}
               className="bg-blue-600 hover:bg-blue-700 shadow-lg shadow-blue-200"
             >
-              <Plus className="h-4 w-4 mr-2" />새 예약
+              새 예약
             </Button>
           </div>
         </div>
@@ -520,13 +546,22 @@ export default function ReservationsPage() {
               </div>
             </div>
 
-            {/* 필터 버튼 (추후 연결) */}
+            {/* ✅ "내 예약만 보기" 토글 버튼 */}
             <Button
-              variant="outline"
+              type="button"
+              variant={myOnly ? 'default' : 'outline'}
               size="sm"
-              className="h-10 px-4 py-2.5 text-sm border-gray-200 hover:bg-gray-50 rounded-lg"
+              aria-pressed={myOnly}
+              onClick={() => setMyOnly(prev => !prev)}
+              className={`h-10 px-4 py-2.5 text-sm rounded-lg transition-all ${
+                myOnly
+                  ? 'bg-blue-600 text-white hover:bg-blue-700 shadow-blue-200 shadow-lg'
+                  : 'border-gray-200 hover:bg-gray-50'
+              }`}
+              title="내 예약만 보기"
             >
               <Filter className="h-4 w-4 mr-2" />내 예약만 보기
+              {myOnly && <Check className="h-4 w-4 ml-2 opacity-90" />}
             </Button>
           </div>
         </div>
@@ -636,7 +671,7 @@ export default function ReservationsPage() {
                         }`}
                         onClick={() => {
                           if (!isPastTime) {
-                            setModalSelectedTime(time); // ← 클릭한 시간 저장
+                            setModalSelectedTime(time);
                             setShowReservationModal(true);
                           }
                         }}
@@ -777,7 +812,7 @@ export default function ReservationsPage() {
                             onClick={() => {
                               if (!isPastDay) {
                                 setSelectedDate(currentDayDate);
-                                setModalSelectedTime(''); // 요일만 클릭 시 시간 비움
+                                setModalSelectedTime('');
                                 setShowReservationModal(true);
                               }
                             }}
@@ -837,6 +872,9 @@ export default function ReservationsPage() {
                         filteredReservations as any[]
                       ).filter(r => r.date === currentDayDateStr);
 
+                      const now = new Date();
+                      const nowMin = now.getHours() * 60 + now.getMinutes();
+
                       return (
                         <div
                           key={dayIndex}
@@ -854,6 +892,9 @@ export default function ReservationsPage() {
                               .padStart(2, '0')}:${minute}`;
 
                             const slotMin = toMinutes(timeStr);
+                            const isPastSlot =
+                              isPastDay || (isToday && slotMin < nowMin);
+
                             const reservation = dayReservations.find(r => {
                               const start = toMinutes((r as any).time);
                               const end = (r as any).endTime
@@ -866,14 +907,14 @@ export default function ReservationsPage() {
                               <div
                                 key={timeIndex}
                                 className={`h-12 border-b border-gray-200 p-1 relative ${
-                                  isPastDay
-                                    ? ''
+                                  isPastSlot
+                                    ? 'opacity-50 pointer-events-none'
                                     : 'cursor-pointer hover:bg-gray-50'
                                 }`}
                                 onClick={() => {
-                                  if (!isPastDay) {
+                                  if (!isPastSlot) {
                                     setSelectedDate(currentDayDate);
-                                    setModalSelectedTime(timeStr); // ← 셀 클릭 시각 저장
+                                    setModalSelectedTime(timeStr);
                                     setShowReservationModal(true);
                                   }
                                 }}
@@ -932,7 +973,7 @@ export default function ReservationsPage() {
         onAddReservation={handleAddReservation}
         room={selectedRoomObj}
         selectedDate={selectedDate || undefined}
-        selectedTime={modalSelectedTime} // ← 클릭된 시간 전달
+        selectedTime={modalSelectedTime}
         timeSlots={timeSlots}
         existingReservations={
           selectedDate instanceof Date

--- a/placeit-frontend/src/app/(dashboard)/reservations/page.tsx
+++ b/placeit-frontend/src/app/(dashboard)/reservations/page.tsx
@@ -10,10 +10,18 @@ import { ReservationModal } from '@/components/reservation/ReservationModal';
 import { useReservationStore } from '@/stores/reservationStore';
 import { formatDateToString } from '@/lib/dateUtils';
 import { timeSlots } from '@/data/sampleData';
-import { ChevronLeft, ChevronRight, Filter, Check } from 'lucide-react';
+import {
+  ChevronLeft,
+  ChevronRight,
+  Filter,
+  Check,
+  Pencil,
+  Trash2,
+} from 'lucide-react';
 import { fetchWorkspaceReservations } from '@/services/reservations';
 import { useActiveWorkspaceId } from '@/lib/workspaceId';
 import { api } from '@/lib/axios';
+import { deleteReservation } from '@/services/reservations';
 
 export default function ReservationsPage() {
   const {
@@ -34,8 +42,10 @@ export default function ReservationsPage() {
   const [modalSelectedTime, setModalSelectedTime] = useState<string>('');
   const currentWsId = useActiveWorkspaceId();
   const [myOnly, setMyOnly] = useState<boolean>(false);
+  const [deletingId, setDeletingId] = useState<string | null>(null);
+  const [editing, setEditing] = useState<any | null>(null);
 
-  // 서버에서 가져오는 공간(회의실) 목록
+  // 서버에서 가져오는 회의실 목록
   type SpaceLite = {
     id: number;
     name: string;
@@ -103,20 +113,17 @@ export default function ReservationsPage() {
         let apiList: any[] = [];
 
         if (myOnly) {
-          // 내 예약만
           const { data } = await api.get('/reservations/my');
           const list = Array.isArray(data) ? data : data?.reservations ?? [];
-          // 현재 워크스페이스에 속한 예약만 남김 (space.workspaceId 또는 space.workspace.id 중 있는 값 사용)
           const wsIdNum = Number(currentWsId);
           apiList = list.filter((r: any) => {
             const s = r.space ?? {};
             const wid = Number(
               s.workspaceId ?? s.workspace?.id ?? r.workspaceId ?? NaN
             );
-            return Number.isFinite(wid) ? wid === wsIdNum : true; // 공간 정보가 없으면 보수적으로 포함
+            return Number.isFinite(wid) ? wid === wsIdNum : true;
           });
         } else {
-          // 워크스페이스 전체
           apiList = await fetchWorkspaceReservations(currentWsId);
         }
 
@@ -179,7 +186,6 @@ export default function ReservationsPage() {
     setModalSelectedTime('');
     setShowReservationModal(true);
   };
-  const handleCloseModal = () => setShowReservationModal(false);
 
   // 새로운 예약 추가
   const handleAddReservation = async (created: any) => {
@@ -217,6 +223,84 @@ export default function ReservationsPage() {
     });
 
     if (success) setShowReservationModal(false);
+  };
+
+  // 예약 수정
+  const handleEditClick = (r: any) => {
+    setEditing(r);
+    setModalSelectedTime(r.time);
+    setShowReservationModal(true);
+  };
+
+  const handleCloseModal = () => {
+    setShowReservationModal(false);
+    setEditing(null);
+  };
+
+  const handleUpdateReservation = (updated: any) => {
+    const toDateStr = (iso: string) => {
+      const d = new Date(iso);
+      return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(
+        2,
+        '0'
+      )}-${String(d.getDate()).padStart(2, '0')}`;
+    };
+    const toTime = (iso: string) => {
+      const d = new Date(iso);
+      return `${String(d.getHours()).padStart(2, '0')}:${String(
+        d.getMinutes()
+      ).padStart(2, '0')}`;
+    };
+
+    const mapped = {
+      id: String(updated.id),
+      title: updated.purpose, // 목적 → 타이틀
+      room: editing?.room ?? updated.space?.name ?? `공간#${updated.spaceId}`,
+      roomId: editing?.roomId ?? String(updated.space?.id ?? updated.spaceId),
+      date: toDateStr(updated.startTime),
+      time: toTime(updated.startTime),
+      endTime: toTime(updated.endTime),
+      attendees: (updated.attendees ?? '')
+        .split(',')
+        .map((s: string) => s.trim())
+        .filter(Boolean),
+      status: (() => {
+        if (updated.status === 'APPROVED') return 'confirmed';
+        if (updated.status === 'REJECTED') return 'cancelled';
+        return 'pending';
+      })(),
+    };
+
+    const next = reservations.map((x: any) =>
+      String(x.id) === String(mapped.id) ? { ...x, ...mapped } : x
+    );
+    setReservations(next);
+
+    setShowReservationModal(false);
+    setEditing(null);
+  };
+
+  // 얘약 삭제
+  const handleDeleteClick = async (r: any) => {
+    try {
+      const id = String(r?.id ?? '');
+      if (!id) return;
+
+      const ok = window.confirm('이 예약을 삭제할까요?');
+      if (!ok) return;
+
+      setDeletingId(id);
+
+      await deleteReservation(id);
+
+      const next = reservations.filter(x => String((x as any).id) !== id);
+      setReservations(next);
+    } catch (e: any) {
+      console.error('예약 삭제 실패', e);
+      alert(e?.response?.data?.message ?? '삭제 중 오류가 발생했습니다.');
+    } finally {
+      setDeletingId(null);
+    }
   };
 
   // UI용 '고유' 예약 배열
@@ -633,7 +717,6 @@ export default function ReservationsPage() {
 
                 {/* 시간대별 예약 현황 */}
                 <div className="border rounded-lg">
-                  {/* 전체 행 높이: 30분 x 17칸 = h-12(3rem) * 17 */}
                   <div className="grid grid-cols-[80px_1fr]">
                     {/* 왼쪽: 시간 라벨 */}
                     <div className="relative">
@@ -651,12 +734,12 @@ export default function ReservationsPage() {
                       })}
                     </div>
 
-                    {/* 오른쪽: 타임라인(배경 라인 + 예약 블록 + 클릭 레이어) */}
+                    {/* 오른쪽: 타임라인 */}
                     <div
                       className="relative"
                       style={{ height: `calc(17 * 3rem)` }}
                     >
-                      {/* 배경 그리드 라인 */}
+                      {/* 배경 그리드 라인 (hover 방해 안 함) */}
                       <div className="absolute inset-0 pointer-events-none">
                         {Array.from({ length: 17 }, (_, i) => (
                           <div
@@ -666,8 +749,8 @@ export default function ReservationsPage() {
                         ))}
                       </div>
 
-                      {/* 예약 블록들 (1건=1블록) */}
-                      <div className="absolute inset-0 px-2">
+                      {/* 예약 블록들 - 가장 위 (z-20) */}
+                      <div className="absolute inset-0 px-2 z-20">
                         {(() => {
                           const selectedDateStr =
                             selectedDate instanceof Date
@@ -690,12 +773,66 @@ export default function ReservationsPage() {
                             return (
                               <div
                                 key={`${(r as any).id}-${idx}`}
-                                className="absolute left-2 right-2 rounded-md border-l-4 border-blue-500 bg-blue-50 shadow-sm p-2 text-xs overflow-hidden"
+                                className="group absolute left-2 right-2 rounded-md border-l-4 border-blue-500 bg-blue-50 shadow-sm p-2 text-xs overflow-hidden"
                                 style={{ top, height }}
                                 title={`${(r as any).time} ~ ${
                                   (r as any).endTime || ''
                                 }`}
                               >
+                                {/* 액션 버튼 */}
+                                <div className="absolute top-1 right-1 z-10 flex gap-1 opacity-100 sm:opacity-0 sm:group-hover:opacity-100 transition-opacity">
+                                  <Button
+                                    size="icon"
+                                    variant="ghost"
+                                    className="h-6 w-6 rounded-md text-gray-700 hover:bg-blue-100 hover:text-blue-700"
+                                    aria-label="예약 수정"
+                                    onClick={e => {
+                                      e.stopPropagation();
+                                      handleEditClick(r);
+                                    }}
+                                  >
+                                    <Pencil className="h-3.5 w-3.5" />
+                                  </Button>
+                                  <Button
+                                    size="icon"
+                                    variant="ghost"
+                                    className="h-6 w-6 rounded-md text-gray-700 hover:bg-rose-100 hover:text-rose-700 disabled:opacity-50"
+                                    aria-label="예약 삭제"
+                                    disabled={
+                                      deletingId === String((r as any).id)
+                                    }
+                                    onClick={e => {
+                                      e.stopPropagation();
+                                      handleDeleteClick(r);
+                                    }}
+                                  >
+                                    {deletingId === String((r as any).id) ? (
+                                      <svg
+                                        className="h-3.5 w-3.5 animate-spin"
+                                        viewBox="0 0 24 24"
+                                      >
+                                        <circle
+                                          cx="12"
+                                          cy="12"
+                                          r="10"
+                                          stroke="currentColor"
+                                          strokeWidth="3"
+                                          fill="none"
+                                          className="opacity-30"
+                                        />
+                                        <path
+                                          d="M12 2a10 10 0 0 1 10 10"
+                                          stroke="currentColor"
+                                          strokeWidth="3"
+                                          fill="none"
+                                        />
+                                      </svg>
+                                    ) : (
+                                      <Trash2 className="h-3.5 w-3.5" />
+                                    )}
+                                  </Button>
+                                </div>
+
                                 <div className="font-semibold truncate">
                                   {(r as any).title}
                                 </div>
@@ -711,8 +848,8 @@ export default function ReservationsPage() {
                         })()}
                       </div>
 
-                      {/* 클릭 레이어: 30분 단위로 모달 오픈 (과거 시간 잠금 유지) */}
-                      <div className="absolute inset-0">
+                      {/* 클릭 레이어 - 블록보다 아래 (z-10) */}
+                      <div className="absolute inset-0 z-10">
                         {Array.from({ length: 17 }, (_, i) => {
                           const hour = Math.floor(i / 2) + 9;
                           const minute = i % 2 === 0 ? '00' : '30';
@@ -910,9 +1047,9 @@ export default function ReservationsPage() {
                           } ${
                             isPastDay ? 'opacity-50 pointer-events-none' : ''
                           }`}
-                          style={{ height: `calc(17 * 3rem)` }} // h-12(=3rem) * 17칸과 동일한 총 높이
+                          style={{ height: `calc(17 * 3rem)` }}
                         >
-                          {/* 배경 그리드 (30분 간격 라인) */}
+                          {/* 배경 그리드 */}
                           <div className="absolute inset-0 pointer-events-none">
                             {Array.from({ length: 17 }, (_, i) => (
                               <div
@@ -923,7 +1060,7 @@ export default function ReservationsPage() {
                           </div>
 
                           {/* 예약 블록들 */}
-                          <div className="absolute inset-0">
+                          <div className="absolute inset-0 z-20">
                             {dayReservations.map((r, idx) => {
                               const { top, height } = toBlockStyle(
                                 (r as any).time,
@@ -932,12 +1069,66 @@ export default function ReservationsPage() {
                               return (
                                 <div
                                   key={`${(r as any).id}-${idx}`}
-                                  className="absolute left-1 right-1 rounded-md border-l-4 border-blue-500 bg-blue-50 shadow-sm p-2 text-xs overflow-hidden"
+                                  className="group absolute left-1 right-1 rounded-md border-l-4 border-blue-500 bg-blue-50 shadow-sm p-2 text-xs overflow-hidden"
                                   style={{ top, height }}
                                   title={`${(r as any).time} ~ ${
                                     (r as any).endTime || ''
                                   }`}
                                 >
+                                  {/* 액션 버튼 */}
+                                  <div className="absolute top-1 right-1 z-10 flex gap-1 opacity-100 sm:opacity-0 sm:group-hover:opacity-100 transition-opacity">
+                                    <Button
+                                      size="icon"
+                                      variant="ghost"
+                                      className="h-6 w-6 rounded-md text-gray-700 hover:bg-blue-100 hover:text-blue-700"
+                                      aria-label="예약 수정"
+                                      onClick={e => {
+                                        e.stopPropagation();
+                                        handleEditClick(r);
+                                      }}
+                                    >
+                                      <Pencil className="h-3.5 w-3.5" />
+                                    </Button>
+                                    <Button
+                                      size="icon"
+                                      variant="ghost"
+                                      className="h-6 w-6 rounded-md text-gray-700 hover:bg-rose-100 hover:text-rose-700 disabled:opacity-50"
+                                      aria-label="예약 삭제"
+                                      disabled={
+                                        deletingId === String((r as any).id)
+                                      }
+                                      onClick={e => {
+                                        e.stopPropagation();
+                                        handleDeleteClick(r);
+                                      }}
+                                    >
+                                      {deletingId === String((r as any).id) ? (
+                                        <svg
+                                          className="h-3.5 w-3.5 animate-spin"
+                                          viewBox="0 0 24 24"
+                                        >
+                                          <circle
+                                            cx="12"
+                                            cy="12"
+                                            r="10"
+                                            stroke="currentColor"
+                                            strokeWidth="3"
+                                            fill="none"
+                                            className="opacity-30"
+                                          />
+                                          <path
+                                            d="M12 2a10 10 0 0 1 10 10"
+                                            stroke="currentColor"
+                                            strokeWidth="3"
+                                            fill="none"
+                                          />
+                                        </svg>
+                                      ) : (
+                                        <Trash2 className="h-3.5 w-3.5" />
+                                      )}
+                                    </Button>
+                                  </div>
+
                                   <div className="font-semibold text-sm truncate">
                                     {(r as any).title}
                                   </div>
@@ -952,8 +1143,8 @@ export default function ReservationsPage() {
                             })}
                           </div>
 
-                          {/* 빈 영역 클릭으로 모달 열기 (셀 단위 클릭 유지) */}
-                          <div className="absolute inset-0">
+                          {/* 빈 영역 클릭 레이어 */}
+                          <div className="absolute inset-0 z-10">
                             {Array.from({ length: 17 }, (_, timeIndex) => {
                               const hour = Math.floor(timeIndex / 2) + 9;
                               const minute = timeIndex % 2 === 0 ? '00' : '30';
@@ -1018,15 +1209,32 @@ export default function ReservationsPage() {
         </Tabs>
       </div>
 
-      {/* 예약 모달 */}
+      {/* 모달 */}
       <ReservationModal
         isOpen={showReservationModal}
         onClose={handleCloseModal}
         onAddReservation={handleAddReservation}
+        onUpdateReservation={handleUpdateReservation}
         room={selectedRoomObj}
         selectedDate={selectedDate || undefined}
         selectedTime={modalSelectedTime}
         timeSlots={timeSlots}
+        mode={editing ? 'edit' : 'create'}
+        editingReservation={
+          editing
+            ? {
+                id: editing.id,
+                date: editing.date,
+                time: editing.time,
+                endTime: editing.endTime,
+                title: editing.title,
+                attendees: Array.isArray(editing.attendees)
+                  ? editing.attendees.join(', ')
+                  : editing.attendees ?? '',
+                notes: editing.notes ?? '',
+              }
+            : undefined
+        }
         existingReservations={
           selectedDate instanceof Date
             ? (filteredReservations as any[])

--- a/placeit-frontend/src/app/(dashboard)/reservations/page.tsx
+++ b/placeit-frontend/src/app/(dashboard)/reservations/page.tsx
@@ -10,7 +10,7 @@ import { ReservationModal } from '@/components/reservation/ReservationModal';
 import { useReservationStore } from '@/stores/reservationStore';
 import { formatDateToString } from '@/lib/dateUtils';
 import { timeSlots } from '@/data/sampleData';
-import { ChevronLeft, ChevronRight, Users, Filter, Check } from 'lucide-react';
+import { ChevronLeft, ChevronRight, Filter, Check } from 'lucide-react';
 import { fetchWorkspaceReservations } from '@/services/reservations';
 import { useActiveWorkspaceId } from '@/lib/workspaceId';
 import { api } from '@/lib/axios';
@@ -33,11 +33,9 @@ export default function ReservationsPage() {
   const [selectedRoomId, setSelectedRoomId] = useState<string>('');
   const [modalSelectedTime, setModalSelectedTime] = useState<string>('');
   const currentWsId = useActiveWorkspaceId();
-
-  // ✅ 새로 추가: "내 예약만 보기" 토글 상태
   const [myOnly, setMyOnly] = useState<boolean>(false);
 
-  // 서버에서 가져오는 공간(회의실) 목록 (capacity 포함)
+  // 서버에서 가져오는 공간(회의실) 목록
   type SpaceLite = {
     id: number;
     name: string;
@@ -76,12 +74,27 @@ export default function ReservationsPage() {
     return 'pending';
   };
 
+  // 09:00 ~ 17:30 타임라인에서 상대 위치 계산
+  const WEEK_BASE_MIN = 9 * 60; // 오전 9시
+  const WEEK_TOTAL_MIN = 17 * 30; // 510분 (09:00~17:30)
+
+  function toBlockStyle(startHHmm: string, endHHmm?: string) {
+    const start = Math.max(0, toMinutes(startHHmm) - WEEK_BASE_MIN);
+    const end = Math.min(
+      WEEK_TOTAL_MIN,
+      (endHHmm ? toMinutes(endHHmm) : toMinutes(startHHmm) + 30) - WEEK_BASE_MIN
+    );
+    const topPct = (start / WEEK_TOTAL_MIN) * 100;
+    const heightPct = Math.max(2, ((end - start) / WEEK_TOTAL_MIN) * 100);
+    return { top: `${topPct}%`, height: `${heightPct}%` };
+  }
+
   // 초기 날짜 설정
   useEffect(() => {
     setSelectedDate(new Date());
   }, [setSelectedDate]);
 
-  // ✅ 예약 불러오기: 워크스페이스 전체 vs 내 예약만
+  // 예약 불러오기: 워크스페이스 전체 vs 내 예약만
   useEffect(() => {
     (async () => {
       try {
@@ -546,7 +559,7 @@ export default function ReservationsPage() {
               </div>
             </div>
 
-            {/* ✅ "내 예약만 보기" 토글 버튼 */}
+            {/* "내 예약만 보기" 토글 버튼 */}
             <Button
               type="button"
               variant={myOnly ? 'default' : 'outline'}
@@ -619,108 +632,122 @@ export default function ReservationsPage() {
                 </div>
 
                 {/* 시간대별 예약 현황 */}
-                <div className="space-y-2">
-                  {timeSlots.map(time => {
-                    const selectedDateStr =
-                      selectedDate instanceof Date
-                        ? `${selectedDate.getFullYear()}-${String(
-                            selectedDate.getMonth() + 1
-                          ).padStart(2, '0')}-${String(
-                            selectedDate.getDate()
-                          ).padStart(2, '0')}`
-                        : '';
-                    const slotMin = toMinutes(time);
+                <div className="border rounded-lg">
+                  {/* 전체 행 높이: 30분 x 17칸 = h-12(3rem) * 17 */}
+                  <div className="grid grid-cols-[80px_1fr]">
+                    {/* 왼쪽: 시간 라벨 */}
+                    <div className="relative">
+                      {Array.from({ length: 17 }, (_, i) => {
+                        const hour = Math.floor(i / 2) + 9;
+                        const minute = i % 2 === 0 ? '00' : '30';
+                        return (
+                          <div
+                            key={i}
+                            className="h-12 border-b border-gray-200 flex items-center justify-end pr-3 text-sm text-gray-600"
+                          >
+                            {`${hour.toString().padStart(2, '0')}:${minute}`}
+                          </div>
+                        );
+                      })}
+                    </div>
 
-                    const reservation = (filteredReservations as any[]).find(
-                      r => {
-                        if (r.date !== selectedDateStr) return false;
-                        const start = toMinutes(r.time);
-                        const end = r.endTime
-                          ? toMinutes(r.endTime)
-                          : start + 30;
-                        return slotMin >= start && slotMin < end;
-                      }
-                    );
+                    {/* 오른쪽: 타임라인(배경 라인 + 예약 블록 + 클릭 레이어) */}
+                    <div
+                      className="relative"
+                      style={{ height: `calc(17 * 3rem)` }}
+                    >
+                      {/* 배경 그리드 라인 */}
+                      <div className="absolute inset-0 pointer-events-none">
+                        {Array.from({ length: 17 }, (_, i) => (
+                          <div
+                            key={i}
+                            className="h-12 border-b border-gray-200"
+                          />
+                        ))}
+                      </div>
 
-                    // 현재 시간과 비교하여 비활성화 여부 결정
-                    const [hour, minute] = time.split(':').map(Number);
-                    const timeInMinutes = hour * 60 + minute;
-                    const currentTime = new Date();
-                    const currentTimeInMinutes =
-                      currentTime.getHours() * 60 + currentTime.getMinutes();
+                      {/* 예약 블록들 (1건=1블록) */}
+                      <div className="absolute inset-0 px-2">
+                        {(() => {
+                          const selectedDateStr =
+                            selectedDate instanceof Date
+                              ? `${selectedDate.getFullYear()}-${String(
+                                  selectedDate.getMonth() + 1
+                                ).padStart(2, '0')}-${String(
+                                  selectedDate.getDate()
+                                ).padStart(2, '0')}`
+                              : '';
 
-                    // 오늘 날짜이고 현재 시간 이전이면 비활성화
-                    const isToday =
-                      selectedDate?.toDateString() ===
-                      currentTime.toDateString();
-                    const isPastTime =
-                      isToday && timeInMinutes < currentTimeInMinutes;
-                    const isCurrentTime =
-                      isToday &&
-                      Math.abs(timeInMinutes - currentTimeInMinutes) <= 15; // ±15분
+                          const dayReservations = (
+                            filteredReservations as any[]
+                          ).filter(r => r.date === selectedDateStr);
 
-                    return (
-                      <div
-                        key={time}
-                        className={`flex items-center gap-4 p-3 border rounded-lg cursor-pointer ${
-                          isPastTime
-                            ? 'border-gray-200 bg-gray-50 opacity-50'
-                            : isCurrentTime
-                            ? 'border-blue-300 bg-blue-50'
-                            : 'border-gray-200 hover:bg-gray-50'
-                        }`}
-                        onClick={() => {
-                          if (!isPastTime) {
-                            setModalSelectedTime(time);
-                            setShowReservationModal(true);
-                          }
-                        }}
-                      >
-                        <div
-                          className={`w-20 text-sm font-medium ${
-                            isPastTime ? 'text-gray-400' : 'text-gray-600'
-                          }`}
-                        >
-                          {time}
-                          {isCurrentTime && (
-                            <span className="ml-2 text-xs text-blue-600 font-bold">
-                              현재
-                            </span>
-                          )}
-                        </div>
-                        <div className="flex-1">
-                          {reservation ? (
-                            <div className="bg-blue-50 p-3 rounded-lg border-l-4 border-blue-500">
-                              <div className="flex items-center justify-between">
-                                <div>
-                                  <h4 className="font-medium text-gray-900">
-                                    {reservation.title}
-                                  </h4>
-                                  <p className="text-sm text-gray-600">
-                                    {reservation.room}
-                                  </p>
-                                  <div className="flex items-center gap-2 mt-1">
-                                    <Users className="h-3 w-3 text-gray-500" />
-                                    <span className="text-xs text-gray-600">
-                                      {reservation.attendees.join(', ')}
-                                    </span>
-                                  </div>
+                          return dayReservations.map((r, idx) => {
+                            const { top, height } = toBlockStyle(
+                              (r as any).time,
+                              (r as any).endTime
+                            );
+                            return (
+                              <div
+                                key={`${(r as any).id}-${idx}`}
+                                className="absolute left-2 right-2 rounded-md border-l-4 border-blue-500 bg-blue-50 shadow-sm p-2 text-xs overflow-hidden"
+                                style={{ top, height }}
+                                title={`${(r as any).time} ~ ${
+                                  (r as any).endTime || ''
+                                }`}
+                              >
+                                <div className="font-semibold truncate">
+                                  {(r as any).title}
+                                </div>
+                                <div className="text-[11px] text-gray-600 truncate">
+                                  {(r as any).room} · {(r as any).time}
+                                  {(r as any).endTime
+                                    ? ` - ${(r as any).endTime}`
+                                    : ''}
                                 </div>
                               </div>
-                            </div>
-                          ) : (
-                            <span
-                              className={
-                                isPastTime ? 'text-gray-300' : 'text-gray-400'
-                              }
-                            >
-                              {isPastTime ? '지난 시간' : '예약 없음'}
-                            </span>
-                          )}
-                        </div>
+                            );
+                          });
+                        })()}
                       </div>
-                    );
-                  })}
+
+                      {/* 클릭 레이어: 30분 단위로 모달 오픈 (과거 시간 잠금 유지) */}
+                      <div className="absolute inset-0">
+                        {Array.from({ length: 17 }, (_, i) => {
+                          const hour = Math.floor(i / 2) + 9;
+                          const minute = i % 2 === 0 ? '00' : '30';
+                          const timeStr = `${hour
+                            .toString()
+                            .padStart(2, '0')}:${minute}`;
+
+                          const now = new Date();
+                          const isToday =
+                            selectedDate?.toDateString() === now.toDateString();
+                          const slotMin =
+                            hour * 60 + (minute === '00' ? 0 : 30);
+                          const nowMin = now.getHours() * 60 + now.getMinutes();
+                          const isPastSlot = isToday && slotMin < nowMin;
+
+                          return (
+                            <div
+                              key={i}
+                              className={`h-12 ${
+                                isPastSlot
+                                  ? 'opacity-50 pointer-events-none'
+                                  : 'cursor-pointer hover:bg-gray-50/60'
+                              }`}
+                              onClick={() => {
+                                if (!isPastSlot) {
+                                  setModalSelectedTime(timeStr);
+                                  setShowReservationModal(true);
+                                }
+                              }}
+                            />
+                          );
+                        })}
+                      </div>
+                    </div>
+                  </div>
                 </div>
               </CardContent>
             </Card>
@@ -878,60 +905,85 @@ export default function ReservationsPage() {
                       return (
                         <div
                           key={dayIndex}
-                          className={`border-r border-gray-200 last:border-r-0 ${
+                          className={`relative border-r border-gray-200 last:border-r-0 ${
                             isToday ? 'bg-blue-50/30' : ''
                           } ${
                             isPastDay ? 'opacity-50 pointer-events-none' : ''
                           }`}
+                          style={{ height: `calc(17 * 3rem)` }} // h-12(=3rem) * 17칸과 동일한 총 높이
                         >
-                          {Array.from({ length: 17 }, (_, timeIndex) => {
-                            const hour = Math.floor(timeIndex / 2) + 9;
-                            const minute = timeIndex % 2 === 0 ? '00' : '30';
-                            const timeStr = `${hour
-                              .toString()
-                              .padStart(2, '0')}:${minute}`;
-
-                            const slotMin = toMinutes(timeStr);
-                            const isPastSlot =
-                              isPastDay || (isToday && slotMin < nowMin);
-
-                            const reservation = dayReservations.find(r => {
-                              const start = toMinutes((r as any).time);
-                              const end = (r as any).endTime
-                                ? toMinutes((r as any).endTime)
-                                : start + 30;
-                              return slotMin >= start && slotMin < end;
-                            });
-
-                            return (
+                          {/* 배경 그리드 (30분 간격 라인) */}
+                          <div className="absolute inset-0 pointer-events-none">
+                            {Array.from({ length: 17 }, (_, i) => (
                               <div
-                                key={timeIndex}
-                                className={`h-12 border-b border-gray-200 p-1 relative ${
-                                  isPastSlot
-                                    ? 'opacity-50 pointer-events-none'
-                                    : 'cursor-pointer hover:bg-gray-50'
-                                }`}
-                                onClick={() => {
-                                  if (!isPastSlot) {
-                                    setSelectedDate(currentDayDate);
-                                    setModalSelectedTime(timeStr);
-                                    setShowReservationModal(true);
-                                  }
-                                }}
-                              >
-                                {reservation && (
-                                  <div className="absolute inset-1 rounded p-1 text-xs bg-gray-100 text-gray-600">
-                                    <div className="font-medium truncate">
-                                      {(reservation as any).title}
-                                    </div>
-                                    <div className="text-xs opacity-75">
-                                      {(reservation as any).room}
-                                    </div>
+                                key={i}
+                                className="h-12 border-b border-gray-200"
+                              />
+                            ))}
+                          </div>
+
+                          {/* 예약 블록들 */}
+                          <div className="absolute inset-0">
+                            {dayReservations.map((r, idx) => {
+                              const { top, height } = toBlockStyle(
+                                (r as any).time,
+                                (r as any).endTime
+                              );
+                              return (
+                                <div
+                                  key={`${(r as any).id}-${idx}`}
+                                  className="absolute left-1 right-1 rounded-md border-l-4 border-blue-500 bg-blue-50 shadow-sm p-2 text-xs overflow-hidden"
+                                  style={{ top, height }}
+                                  title={`${(r as any).time} ~ ${
+                                    (r as any).endTime || ''
+                                  }`}
+                                >
+                                  <div className="font-semibold text-sm truncate">
+                                    {(r as any).title}
                                   </div>
-                                )}
-                              </div>
-                            );
-                          })}
+                                  <div className="text-[11px] text-gray-600 truncate">
+                                    {(r as any).room} · {(r as any).time}
+                                    {(r as any).endTime
+                                      ? ` - ${(r as any).endTime}`
+                                      : ''}
+                                  </div>
+                                </div>
+                              );
+                            })}
+                          </div>
+
+                          {/* 빈 영역 클릭으로 모달 열기 (셀 단위 클릭 유지) */}
+                          <div className="absolute inset-0">
+                            {Array.from({ length: 17 }, (_, timeIndex) => {
+                              const hour = Math.floor(timeIndex / 2) + 9;
+                              const minute = timeIndex % 2 === 0 ? '00' : '30';
+                              const timeStr = `${hour
+                                .toString()
+                                .padStart(2, '0')}:${minute}`;
+                              const slotMin =
+                                hour * 60 + (minute === '00' ? 0 : 30);
+                              const isPastSlot =
+                                isPastDay || (isToday && slotMin < nowMin);
+
+                              return (
+                                <div
+                                  key={timeIndex}
+                                  className={`h-12 p-1 ${
+                                    isPastSlot
+                                      ? 'pointer-events-none'
+                                      : 'cursor-pointer'
+                                  }`}
+                                  onClick={() => {
+                                    if (!isPastSlot) {
+                                      setSelectedDate(currentDayDate);
+                                      setModalSelectedTime(timeStr);
+                                      setShowReservationModal(true);
+                                    }
+                                  }}
+                                />
+                              );
+                            })}
+                          </div>
                         </div>
                       );
                     })}

--- a/placeit-frontend/src/app/(dashboard)/reservations/page.tsx
+++ b/placeit-frontend/src/app/(dashboard)/reservations/page.tsx
@@ -31,6 +31,7 @@ export default function ReservationsPage() {
 
   const [showReservationModal, setShowReservationModal] = useState(false);
   const [selectedRoom, setSelectedRoom] = useState<string>('');
+  const [selectedRoomId, setSelectedRoomId] = useState<string>('');
   const currentWsId = useActiveWorkspaceId();
 
   const toDateStr = (iso: string) => {
@@ -85,6 +86,8 @@ export default function ReservationsPage() {
           id: String(r.id),
           title: r.purpose,
           room: r.space?.name ?? `공간#${r.spaceId}`,
+          roomId: String(r.space?.id ?? r.spaceId),
+
           date: toDateStr(r.startTime),
           time: toTimeHHmm(r.startTime),
           endTime: toTimeHHmm(r.endTime),
@@ -115,17 +118,42 @@ export default function ReservationsPage() {
 
   // 새로운 예약 추가
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const handleAddReservation = async (newReservation: any) => {
+  const handleAddReservation = async (created: any) => {
+    // 서버 응답(ISO) → UI 표시용 포맷으로 변환
+    const dateStr = toDateStr(created.startTime);
+    const startHHmm = toTimeHHmm(created.startTime);
+    const endHHmm = toTimeHHmm(created.endTime);
+
+    const roomName =
+      created?.space?.name ?? `공간#${created.spaceId ?? '알수없음'}`;
+
+    const attendees =
+      typeof created.attendees === 'string' &&
+      created.attendees.trim().length > 0
+        ? created.attendees
+            .split(',')
+            .map((s: string) => s.trim())
+            .filter(Boolean)
+        : [];
+
+    const status =
+      created?.status === 'APPROVED'
+        ? ('confirmed' as const)
+        : created?.status === 'REJECTED'
+        ? ('cancelled' as const)
+        : ('pending' as const);
+
     const success = await addReservation({
-      title: newReservation.title,
-      room: newReservation.room,
-      date: newReservation.date,
-      time: newReservation.time,
-      attendees: newReservation.attendees
-        ? newReservation.attendees.split(',').map((s: string) => s.trim())
-        : [],
-      status: 'confirmed' as const,
+      id: String(created.id ?? `${Date.now()}`),
+      title: created.purpose,
+      room: roomName,
+      date: dateStr,
+      time: startHHmm,
+      endTime: endHHmm,
+      attendees,
+      status,
     });
+
     if (success) setShowReservationModal(false);
   };
 
@@ -141,14 +169,34 @@ export default function ReservationsPage() {
 
   // 방 이름 옵션
   const roomOptions = useMemo(() => {
-    return Array.from(new Set(uniqueReservations.map(r => r.room))).sort();
+    const idToName = new Map<string, string>();
+    for (const r of uniqueReservations) {
+      if (r.roomId) idToName.set(r.roomId, r.room);
+    }
+    return Array.from(idToName, ([id, name]) => ({ id, name })).sort((a, b) =>
+      a.name.localeCompare(b.name)
+    );
   }, [uniqueReservations]);
 
   // 공간별 토글/선택에 따른 필터링
   const filteredReservations = useMemo(() => {
-    if (!selectedRoom) return []; // 아무 것도 선택 안 하면 빈 목록
-    return uniqueReservations.filter(r => r.room === selectedRoom);
-  }, [uniqueReservations, selectedRoom]);
+    if (!selectedRoomId) return [];
+    return uniqueReservations.filter(r => r.roomId === selectedRoomId);
+  }, [uniqueReservations, selectedRoomId]);
+
+  const selectedRoomObj = useMemo(() => {
+    if (!selectedRoomId) return null;
+    const found = roomOptions.find(r => r.id === selectedRoomId);
+    if (!found) return null;
+    return {
+      id: found.id,
+      name: found.name,
+      description: '',
+      capacity: 0,
+      features: [],
+    };
+  }, [roomOptions, selectedRoomId]);
+
   // 월 뷰
   const monthReservations = useMemo(() => {
     // 날짜별 그룹화
@@ -282,14 +330,14 @@ export default function ReservationsPage() {
           <div className="flex items-center gap-3">
             {/* 공간 선택 */}
             <select
-              value={selectedRoom}
-              onChange={e => setSelectedRoom(e.target.value)}
+              value={selectedRoomId}
+              onChange={e => setSelectedRoomId(e.target.value)}
               className="h-10 pl-3 pr-8 border border-gray-200 rounded-lg text-sm text-gray-700 bg-white shadow-sm"
             >
               <option value="">공간 선택…</option>
-              {roomOptions.map(room => (
-                <option key={room} value={room}>
-                  {room}
+              {roomOptions.map(opt => (
+                <option key={opt.id} value={opt.id}>
+                  {opt.name}
                 </option>
               ))}
             </select>
@@ -830,13 +878,7 @@ export default function ReservationsPage() {
         isOpen={showReservationModal}
         onClose={handleCloseModal}
         onAddReservation={handleAddReservation}
-        room={{
-          id: '1',
-          name: '회의실1',
-          description: '일반적인 회의에 적합한 회의실',
-          capacity: 8,
-          features: ['프로젝터', '화이트보드', 'WiFi'],
-        }}
+        room={selectedRoomObj}
         selectedDate={selectedDate || undefined}
         selectedTime="10:00"
         timeSlots={timeSlots}

--- a/placeit-frontend/src/app/(dashboard)/reservations/requests/page.tsx
+++ b/placeit-frontend/src/app/(dashboard)/reservations/requests/page.tsx
@@ -69,6 +69,8 @@ export default function ReservationRequestsPage() {
     'all' | 'PENDING' | 'APPROVED' | 'REJECTED'
   >('all');
   const [searchTerm, setSearchTerm] = useState('');
+  const [approvingIds, setApprovingIds] = useState<Set<number>>(new Set());
+  const [rejectingIds, setRejectingIds] = useState<Set<number>>(new Set());
   const workspaceId = useWorkspaceStore(state => state.currentId);
 
   useEffect(() => {
@@ -79,7 +81,7 @@ export default function ReservationRequestsPage() {
         const res = await api.get<{ reservations: Reservation[] }>(
           `/workspaces/${workspaceId}/reservations`
         );
-        // 공간이 승인 필요(requiresApproval: true)인 예약만 보관
+        // 승인 필요 공간만 필터
         const onlyApprovalRequired = (res.data.reservations || []).filter(
           r => r.space?.requiresApproval === true
         );
@@ -96,43 +98,101 @@ export default function ReservationRequestsPage() {
 
   const filteredRequests = useMemo(() => {
     const term = searchTerm.trim().toLowerCase();
-    return requests.filter(request => {
-      const matchesStatus =
-        filterStatus === 'all' || request.status === filterStatus;
-      const matchesSearch =
-        term === '' ||
-        request.purpose?.toLowerCase().includes(term) ||
-        request.memo?.toLowerCase().includes(term) ||
-        request.user?.name?.toLowerCase().includes(term) ||
-        request.space?.name?.toLowerCase().includes(term);
-      // 추가 안전망: 공간이 승인 필요인 것만
-      const matchesApproval = request.space?.requiresApproval === true;
-      return matchesStatus && matchesSearch && matchesApproval;
-    });
+    return requests
+      .filter(request => {
+        const matchesStatus =
+          filterStatus === 'all' || request.status === filterStatus;
+        const matchesSearch =
+          term === '' ||
+          request.purpose?.toLowerCase().includes(term) ||
+          request.memo?.toLowerCase().includes(term) ||
+          request.user?.name?.toLowerCase().includes(term) ||
+          request.space?.name?.toLowerCase().includes(term);
+        const matchesApproval = request.space?.requiresApproval === true;
+        return matchesStatus && matchesSearch && matchesApproval;
+      })
+      .sort(
+        (a, b) =>
+          new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
+      );
   }, [requests, filterStatus, searchTerm]);
 
-  const handleApprove = (requestId: number) => {
-    setRequests(prev =>
-      prev.map(req =>
+  // 예약 요청 승인
+  const handleApprove = async (requestId: number) => {
+    if (approvingIds.has(requestId)) return;
+
+    const prev = requests.find(r => r.id === requestId)?.status;
+
+    setRequests(prevList =>
+      prevList.map(req =>
         req.id === requestId
           ? ({ ...req, status: 'APPROVED' } as Reservation)
           : req
       )
     );
+    setApprovingIds(prevSet => new Set(prevSet).add(requestId));
+
+    try {
+      await api.post(`/reservations/${requestId}/approve`);
+    } catch (e) {
+      console.error('예약 승인 실패', e);
+      setRequests(prevList =>
+        prevList.map(req =>
+          req.id === requestId
+            ? ({ ...req, status: prev ?? 'PENDING' } as Reservation)
+            : req
+        )
+      );
+      alert('승인 처리에 실패했습니다. 잠시 후 다시 시도해주세요.');
+    } finally {
+      setApprovingIds(prevSet => {
+        const next = new Set(prevSet);
+        next.delete(requestId);
+        return next;
+      });
+    }
   };
 
-  const handleReject = (requestId: number) => {
-    setRequests(prev =>
-      prev.map(req =>
+  // 예약 요청 거절
+  const handleReject = async (requestId: number) => {
+    if (rejectingIds.has(requestId)) return;
+
+    const prev = requests.find(r => r.id === requestId)?.status;
+
+    setRequests(prevList =>
+      prevList.map(req =>
         req.id === requestId
           ? ({ ...req, status: 'REJECTED' } as Reservation)
           : req
       )
     );
+    setRejectingIds(prevSet => new Set(prevSet).add(requestId));
+
+    try {
+      await api.post(`/reservations/${requestId}/reject`);
+    } catch (e) {
+      console.error('예약 거절 실패', e);
+      setRequests(prevList =>
+        prevList.map(req =>
+          req.id === requestId
+            ? ({ ...req, status: prev ?? 'PENDING' } as Reservation)
+            : req
+        )
+      );
+      alert('거절 처리에 실패했습니다. 잠시 후 다시 시도해주세요.');
+    } finally {
+      setRejectingIds(prevSet => {
+        const next = new Set(prevSet);
+        next.delete(requestId);
+        return next;
+      });
+    }
   };
 
   const formatDateTime = (dateTimeStr: string) => {
     const date = new Date(dateTimeStr);
+    date.setHours(date.getHours() + 9); // +9시간
+
     const mm = (date.getMonth() + 1).toString().padStart(2, '0');
     const dd = date.getDate().toString().padStart(2, '0');
     const hh = date.getHours().toString().padStart(2, '0');
@@ -274,96 +334,125 @@ export default function ReservationRequestsPage() {
               </CardContent>
             </Card>
           ) : (
-            filteredRequests.map(request => (
-              <Card
-                key={request.id}
-                className="hover:shadow-md transition-shadow duration-200"
-              >
-                <CardContent className="p-6">
-                  <div className="flex items-start justify-between mb-4">
-                    <div className="flex-1">
-                      <div className="flex items-center gap-3 mb-2">
-                        <h3 className="text-lg font-semibold text-gray-900">
-                          {request.purpose || '회의'}
-                        </h3>
-                        <Badge
-                          className={`text-xs ${getStatusColor(
-                            request.status
-                          )}`}
-                        >
-                          {getStatusLabel(request.status)}
-                        </Badge>
-                        <Badge variant="outline" className="text-xs">
-                          승인 필요
-                        </Badge>
+            filteredRequests.map(request => {
+              const approving = approvingIds.has(request.id);
+              const rejecting = rejectingIds.has(request.id);
+
+              return (
+                <Card
+                  key={request.id}
+                  className="hover:shadow-md transition-shadow duration-200"
+                >
+                  <CardContent className="p-6">
+                    <div className="flex items-start justify-between mb-4">
+                      <div className="flex-1">
+                        <div className="flex items-center gap-3 mb-2">
+                          <h3 className="text-lg font-semibold text-gray-900">
+                            {request.purpose || '회의'}
+                          </h3>
+                          <Badge
+                            className={`text-xs ${getStatusColor(
+                              request.status
+                            )}`}
+                          >
+                            {getStatusLabel(request.status)}
+                          </Badge>
+                          <Badge variant="outline" className="text-xs">
+                            승인 필요
+                          </Badge>
+                        </div>
+
+                        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 text-sm text-gray-600">
+                          <div className="flex items-center gap-2">
+                            <Calendar className="w-4 h-4" />
+                            <span>
+                              {formatDateTime(request.startTime)} ~{' '}
+                              {formatDateTime(request.endTime)}
+                            </span>
+                          </div>
+                          <div className="flex items-center gap-2">
+                            <User className="w-4 h-4" />
+                            <span>
+                              {request.user?.name ??
+                                `사용자 #${request.userId}`}
+                            </span>
+                          </div>
+                          <div className="flex items-center gap-2">
+                            <MapPin className="w-4 h-4" />
+                            <span>
+                              {request.space?.name ??
+                                `회의실 #${request.spaceId}`}
+                            </span>
+                          </div>
+                        </div>
                       </div>
 
-                      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 text-sm text-gray-600">
-                        <div className="flex items-center gap-2">
-                          <Calendar className="w-4 h-4" />
-                          <span>
-                            {formatDateTime(request.startTime)} ~{' '}
-                            {formatDateTime(request.endTime)}
-                          </span>
+                      {request.status === 'PENDING' && (
+                        <div className="flex gap-2 ml-4">
+                          <Button
+                            size="sm"
+                            onClick={() => handleApprove(request.id)}
+                            disabled={approving || rejecting}
+                            className="bg-green-600 hover:bg-green-700 text-white whitespace-nowrap disabled:opacity-60 disabled:cursor-not-allowed"
+                          >
+                            {approving ? (
+                              <>
+                                <Clock className="w-4 h-4 mr-1 animate-spin" />
+                                승인 중…
+                              </>
+                            ) : (
+                              <>
+                                <Check className="w-4 h-4 mr-1" />
+                                승인
+                              </>
+                            )}
+                          </Button>
+
+                          <Button
+                            size="sm"
+                            variant="outline"
+                            onClick={() => handleReject(request.id)}
+                            disabled={approving || rejecting}
+                            className="text-red-600 border-red-300 hover:bg-red-50 hover:text-red-700 whitespace-nowrap disabled:opacity-60 disabled:cursor-not-allowed"
+                          >
+                            {rejecting ? (
+                              <>
+                                <Clock className="w-4 h-4 mr-1 animate-spin" />
+                                거절 중…
+                              </>
+                            ) : (
+                              <>
+                                <X className="w-4 h-4 mr-1" />
+                                거절
+                              </>
+                            )}
+                          </Button>
                         </div>
-                        <div className="flex items-center gap-2">
-                          <User className="w-4 h-4" />
-                          <span>
-                            {request.user?.name ?? `사용자 #${request.userId}`}
-                          </span>
-                        </div>
-                        <div className="flex items-center gap-2">
-                          <MapPin className="w-4 h-4" />
-                          <span>
-                            {request.space?.name ??
-                              `회의실 #${request.spaceId}`}
-                          </span>
-                        </div>
+                      )}
+                    </div>
+
+                    {/* 상세 정보 */}
+                    <div className="bg-gray-50 rounded-lg p-4 space-y-3">
+                      <div>
+                        <h4 className="text-sm font-medium text-gray-900 mb-1">
+                          회의 목적
+                        </h4>
+                        <p className="text-sm text-gray-700">
+                          {request.purpose || '-'}
+                        </p>
+                      </div>
+
+                      <div className="flex items-center justify-between text-xs text-gray-500">
+                        <span>메모: {request.memo || '-'}</span>
+                        <span>
+                          신청일시: {formatDateTime(request.createdAt)}
+                        </span>
                       </div>
                     </div>
-
-                    {request.status === 'PENDING' && (
-                      <div className="flex gap-2 ml-4">
-                        <Button
-                          size="sm"
-                          onClick={() => handleApprove(request.id)}
-                          className="bg-green-600 hover:bg-green-700 text-white whitespace-nowrap"
-                        >
-                          <Check className="w-4 h-4 mr-1" />
-                          승인
-                        </Button>
-                        <Button
-                          size="sm"
-                          variant="outline"
-                          onClick={() => handleReject(request.id)}
-                          className="text-red-600 border-red-300 hover:bg-red-50 hover:text-red-700 whitespace-nowrap"
-                        >
-                          <X className="w-4 h-4 mr-1" />
-                          거부
-                        </Button>
-                      </div>
-                    )}
-                  </div>
-
-                  {/* 상세 정보 */}
-                  <div className="bg-gray-50 rounded-lg p-4 space-y-3">
-                    <div>
-                      <h4 className="text-sm font-medium text-gray-900 mb-1">
-                        회의 목적
-                      </h4>
-                      <p className="text-sm text-gray-700">
-                        {request.purpose || '-'}
-                      </p>
-                    </div>
-
-                    <div className="flex items-center justify-between text-xs text-gray-500">
-                      <span>메모: {request.memo || '-'}</span>
-                      <span>신청일시: {formatDateTime(request.createdAt)}</span>
-                    </div>
-                  </div>
-                </CardContent>
-              </Card>
-            ))
+                  </CardContent>
+                </Card>
+              );
+            })
           )}
         </div>
       </div>

--- a/placeit-frontend/src/app/(dashboard)/reservations/requests/page.tsx
+++ b/placeit-frontend/src/app/(dashboard)/reservations/requests/page.tsx
@@ -189,9 +189,9 @@ export default function ReservationRequestsPage() {
     }
   };
 
-  const formatDateTime = (dateTimeStr: string) => {
+  const formatDateTime = (dateTimeStr: string, addHours = 0) => {
     const date = new Date(dateTimeStr);
-    date.setHours(date.getHours() + 9); // +9시간
+    if (addHours) date.setHours(date.getHours() + addHours);
 
     const mm = (date.getMonth() + 1).toString().padStart(2, '0');
     const dd = date.getDate().toString().padStart(2, '0');
@@ -362,22 +362,22 @@ export default function ReservationRequestsPage() {
                           </Badge>
                         </div>
 
-                        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 text-sm text-gray-600">
-                          <div className="flex items-center gap-2">
+                        <div className="flex flex-wrap gap-6 text-sm text-gray-600">
+                          <div className="flex items-center gap-1">
                             <Calendar className="w-4 h-4" />
                             <span>
                               {formatDateTime(request.startTime)} ~{' '}
                               {formatDateTime(request.endTime)}
                             </span>
                           </div>
-                          <div className="flex items-center gap-2">
+                          <div className="flex items-center gap-1">
                             <User className="w-4 h-4" />
                             <span>
                               {request.user?.name ??
                                 `사용자 #${request.userId}`}
                             </span>
                           </div>
-                          <div className="flex items-center gap-2">
+                          <div className="flex items-center gap-1">
                             <MapPin className="w-4 h-4" />
                             <span>
                               {request.space?.name ??
@@ -435,19 +435,23 @@ export default function ReservationRequestsPage() {
                     <div className="bg-gray-50 rounded-lg p-4 space-y-3">
                       <div>
                         <h4 className="text-sm font-medium text-gray-900 mb-1">
-                          회의 목적
+                          참석자 목록
                         </h4>
                         <p className="text-sm text-gray-700">
-                          {request.purpose || '-'}
+                          {request.attendees || '-'}
+                        </p>
+                        <h4 className="text-sm font-medium text-gray-900 mt-2 mb-1">
+                          설명
+                        </h4>
+                        <p className="text-sm text-gray-700">
+                          {request.memo || '-'}
                         </p>
                       </div>
-
-                      <div className="flex items-center justify-between text-xs text-gray-500">
-                        <span>메모: {request.memo || '-'}</span>
-                        <span>
-                          신청일시: {formatDateTime(request.createdAt)}
-                        </span>
-                      </div>
+                    </div>
+                    <div className="flex justify-end text-xs text-gray-500 mt-2">
+                      <span>
+                        신청일시: {formatDateTime(request.createdAt, 9)}
+                      </span>
                     </div>
                   </CardContent>
                 </Card>

--- a/placeit-frontend/src/app/(dashboard)/reservations/requests/page.tsx
+++ b/placeit-frontend/src/app/(dashboard)/reservations/requests/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { MainLayout } from '@/components/layout/MainLayout';
 import {
   Clock,
@@ -16,84 +16,107 @@ import { Card, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { StatCard } from '@/components/management/StatCard';
+import { api } from '@/lib/axios';
+import { useWorkspaceStore } from '@/stores/workspaceStore';
 
-const sampleRequests = [
-  {
-    id: 1,
-    title: '마케팅 전략 회의',
-    requester: '김민지',
-    department: '마케팅팀',
-    spaceName: '대회의실',
-    date: '2024-01-19',
-    startTime: '10:00',
-    endTime: '11:30',
-    duration: '1시간 30분',
-    attendees: 8,
-    purpose: 'Q1 마케팅 전략 수립 및 캠페인 기획',
-    priority: 'high',
-    requestedAt: '2024-01-18 09:30',
-    status: 'pending',
-  },
-  {
-    id: 2,
-    title: '개발팀 스프린트 리뷰',
-    requester: '박성호',
-    department: '개발팀',
-    spaceName: '회의실1',
-    date: '2024-01-19',
-    startTime: '14:00',
-    endTime: '15:00',
-    duration: '1시간',
-    attendees: 6,
-    purpose: '2주차 스프린트 결과 리뷰 및 다음 스프린트 계획',
-    priority: 'medium',
-    requestedAt: '2024-01-18 11:15',
-    status: 'pending',
-  },
-  {
-    id: 3,
-    title: '임원진 월간 회의',
-    requester: '이정우',
-    department: '경영진',
-    spaceName: '임원회의실',
-    date: '2024-01-20',
-    startTime: '09:00',
-    endTime: '11:00',
-    duration: '2시간',
-    attendees: 12,
-    purpose: '월간 실적 검토 및 향후 전략 논의',
-    priority: 'high',
-    requestedAt: '2024-01-18 08:45',
-    status: 'pending',
-  },
-  {
-    id: 4,
-    title: '신입사원 교육',
-    requester: '최유리',
-    department: '인사팀',
-    spaceName: '세미나실',
-    date: '2024-01-22',
-    startTime: '13:00',
-    endTime: '17:00',
-    duration: '4시간',
-    attendees: 15,
-    purpose: '신입사원 온보딩 교육 프로그램',
-    priority: 'medium',
-    requestedAt: '2024-01-18 14:20',
-    status: 'pending',
-  },
-];
+type Space = {
+  id: number;
+  workspaceId: number;
+  name: string;
+  description: string | null;
+  location: string | null;
+  capacity: number;
+  requiresApproval: boolean;
+  isActive: boolean;
+  amenities: string[];
+  createdAt: string;
+  updatedAt: string;
+  deleted: boolean;
+};
+
+type ReqUser = {
+  id: number;
+  email: string;
+  provider: string;
+  providerId: string;
+  name: string;
+  phone: string | null;
+  createdAt: string;
+  updatedAt: string;
+  isActive: boolean;
+};
+
+type Reservation = {
+  id: number;
+  spaceId: number;
+  userId: number;
+  attendees: string;
+  memo: string;
+  startTime: string;
+  endTime: string;
+  status: 'PENDING' | 'APPROVED' | 'REJECTED' | string;
+  purpose: string;
+  createdAt: string;
+  updatedAt: string;
+  space: Space;
+  user: ReqUser;
+};
 
 export default function ReservationRequestsPage() {
-  const [requests, setRequests] = useState(sampleRequests);
-  const [filterStatus, setFilterStatus] = useState('all');
-  const [filterPriority, setFilterPriority] = useState('all');
+  const [requests, setRequests] = useState<Reservation[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [filterStatus, setFilterStatus] = useState<
+    'all' | 'PENDING' | 'APPROVED' | 'REJECTED'
+  >('all');
   const [searchTerm, setSearchTerm] = useState('');
+  const workspaceId = useWorkspaceStore(state => state.currentId);
+
+  useEffect(() => {
+    const fetchReservations = async () => {
+      if (!workspaceId) return;
+      setLoading(true);
+      try {
+        const res = await api.get<{ reservations: Reservation[] }>(
+          `/workspaces/${workspaceId}/reservations`
+        );
+        // 공간이 승인 필요(requiresApproval: true)인 예약만 보관
+        const onlyApprovalRequired = (res.data.reservations || []).filter(
+          r => r.space?.requiresApproval === true
+        );
+        setRequests(onlyApprovalRequired);
+      } catch (e) {
+        console.error('예약 불러오기 실패', e);
+        setRequests([]);
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchReservations();
+  }, [workspaceId]);
+
+  const filteredRequests = useMemo(() => {
+    const term = searchTerm.trim().toLowerCase();
+    return requests.filter(request => {
+      const matchesStatus =
+        filterStatus === 'all' || request.status === filterStatus;
+      const matchesSearch =
+        term === '' ||
+        request.purpose?.toLowerCase().includes(term) ||
+        request.memo?.toLowerCase().includes(term) ||
+        request.user?.name?.toLowerCase().includes(term) ||
+        request.space?.name?.toLowerCase().includes(term);
+      // 추가 안전망: 공간이 승인 필요인 것만
+      const matchesApproval = request.space?.requiresApproval === true;
+      return matchesStatus && matchesSearch && matchesApproval;
+    });
+  }, [requests, filterStatus, searchTerm]);
 
   const handleApprove = (requestId: number) => {
     setRequests(prev =>
       prev.map(req =>
-        req.id === requestId ? { ...req, status: 'approved' } : req
+        req.id === requestId
+          ? ({ ...req, status: 'APPROVED' } as Reservation)
+          : req
       )
     );
   };
@@ -101,74 +124,29 @@ export default function ReservationRequestsPage() {
   const handleReject = (requestId: number) => {
     setRequests(prev =>
       prev.map(req =>
-        req.id === requestId ? { ...req, status: 'rejected' } : req
+        req.id === requestId
+          ? ({ ...req, status: 'REJECTED' } as Reservation)
+          : req
       )
     );
   };
 
-  const filteredRequests = requests.filter(request => {
-    const matchesStatus =
-      filterStatus === 'all' || request.status === filterStatus;
-    const matchesPriority =
-      filterPriority === 'all' || request.priority === filterPriority;
-    const matchesSearch =
-      searchTerm === '' ||
-      request.title.toLowerCase().includes(searchTerm.toLowerCase()) ||
-      request.requester.toLowerCase().includes(searchTerm.toLowerCase()) ||
-      request.department.toLowerCase().includes(searchTerm.toLowerCase());
-
-    return matchesStatus && matchesPriority && matchesSearch;
-  });
-
-  const formatDate = (dateStr: string) => {
-    const date = new Date(dateStr);
-    const weekdays = ['일', '월', '화', '수', '목', '금', '토'];
-    return `${date.getMonth() + 1}월 ${date.getDate()}일 (${
-      weekdays[date.getDay()]
-    })`;
-  };
-
   const formatDateTime = (dateTimeStr: string) => {
     const date = new Date(dateTimeStr);
-    return `${date.getMonth() + 1}/${date.getDate()} ${date
-      .getHours()
-      .toString()
-      .padStart(2, '0')}:${date.getMinutes().toString().padStart(2, '0')}`;
-  };
-
-  const getPriorityColor = (priority: string) => {
-    switch (priority) {
-      case 'high':
-        return 'bg-red-100 text-red-800 border-red-300';
-      case 'medium':
-        return 'bg-yellow-100 text-yellow-800 border-yellow-300';
-      case 'low':
-        return 'bg-green-100 text-green-800 border-green-300';
-      default:
-        return 'bg-gray-100 text-gray-800 border-gray-300';
-    }
-  };
-
-  const getPriorityLabel = (priority: string) => {
-    switch (priority) {
-      case 'high':
-        return '긴급';
-      case 'medium':
-        return '보통';
-      case 'low':
-        return '낮음';
-      default:
-        return '보통';
-    }
+    const mm = (date.getMonth() + 1).toString().padStart(2, '0');
+    const dd = date.getDate().toString().padStart(2, '0');
+    const hh = date.getHours().toString().padStart(2, '0');
+    const mi = date.getMinutes().toString().padStart(2, '0');
+    return `${mm}/${dd} ${hh}:${mi}`;
   };
 
   const getStatusColor = (status: string) => {
     switch (status) {
-      case 'pending':
+      case 'PENDING':
         return 'bg-yellow-100 text-yellow-800';
-      case 'approved':
+      case 'APPROVED':
         return 'bg-green-100 text-green-800';
-      case 'rejected':
+      case 'REJECTED':
         return 'bg-red-100 text-red-800';
       default:
         return 'bg-gray-100 text-gray-800';
@@ -177,20 +155,20 @@ export default function ReservationRequestsPage() {
 
   const getStatusLabel = (status: string) => {
     switch (status) {
-      case 'pending':
+      case 'PENDING':
         return '대기중';
-      case 'approved':
+      case 'APPROVED':
         return '승인됨';
-      case 'rejected':
+      case 'REJECTED':
         return '거부됨';
       default:
-        return '대기중';
+        return status;
     }
   };
 
-  const pendingCount = requests.filter(r => r.status === 'pending').length;
-  const approvedCount = requests.filter(r => r.status === 'approved').length;
-  const rejectedCount = requests.filter(r => r.status === 'rejected').length;
+  const pendingCount = requests.filter(r => r.status === 'PENDING').length;
+  const approvedCount = requests.filter(r => r.status === 'APPROVED').length;
+  const rejectedCount = requests.filter(r => r.status === 'REJECTED').length;
 
   return (
     <MainLayout activePage="reservation-requests">
@@ -202,7 +180,7 @@ export default function ReservationRequestsPage() {
               예약 요청 관리
             </h1>
             <p className="text-gray-600 mt-2">
-              대기 중인 예약 요청을 승인하거나 거부하세요
+              승인이 필요한 공간 예약만 표시합니다.
             </p>
           </div>
         </div>
@@ -245,7 +223,7 @@ export default function ReservationRequestsPage() {
                   <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-500 w-4 h-4" />
                   <input
                     type="text"
-                    placeholder="제목, 신청자, 부서로 검색..."
+                    placeholder="목적, 메모, 신청자, 공간명으로 검색..."
                     value={searchTerm}
                     onChange={e => setSearchTerm(e.target.value)}
                     className="w-full pl-10 pr-4 py-2 border border-gray-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 text-sm"
@@ -257,42 +235,20 @@ export default function ReservationRequestsPage() {
               <div className="flex bg-gray-100 rounded-lg p-1">
                 {[
                   { id: 'all', label: '전체' },
-                  { id: 'pending', label: '대기중' },
-                  { id: 'approved', label: '승인됨' },
-                  { id: 'rejected', label: '거부됨' },
-                ].map(status => (
+                  { id: 'PENDING', label: '대기중' },
+                  { id: 'APPROVED', label: '승인됨' },
+                  { id: 'REJECTED', label: '거부됨' },
+                ].map(s => (
                   <button
-                    key={status.id}
-                    onClick={() => setFilterStatus(status.id)}
+                    key={s.id}
+                    onClick={() => setFilterStatus(s.id as typeof filterStatus)}
                     className={`px-3 py-1 rounded-md text-sm font-medium transition-all ${
-                      filterStatus === status.id
+                      filterStatus === s.id
                         ? 'bg-white shadow-sm text-gray-900'
                         : 'text-gray-600 hover:text-gray-900'
                     }`}
                   >
-                    {status.label}
-                  </button>
-                ))}
-              </div>
-
-              {/* 우선순위 필터 */}
-              <div className="flex bg-gray-100 rounded-lg p-1">
-                {[
-                  { id: 'all', label: '모든 우선순위' },
-                  { id: 'high', label: '긴급' },
-                  { id: 'medium', label: '보통' },
-                  { id: 'low', label: '낮음' },
-                ].map(priority => (
-                  <button
-                    key={priority.id}
-                    onClick={() => setFilterPriority(priority.id)}
-                    className={`px-3 py-1 rounded-md text-sm font-medium transition-all whitespace-nowrap ${
-                      filterPriority === priority.id
-                        ? 'bg-white shadow-sm text-gray-900'
-                        : 'text-gray-600 hover:text-gray-900'
-                    }`}
-                  >
-                    {priority.label}
+                    {s.label}
                   </button>
                 ))}
               </div>
@@ -302,7 +258,13 @@ export default function ReservationRequestsPage() {
 
         {/* 예약 요청 목록 */}
         <div className="space-y-4">
-          {filteredRequests.length === 0 ? (
+          {loading ? (
+            <Card>
+              <CardContent className="p-8 text-center text-gray-600">
+                불러오는 중…
+              </CardContent>
+            </Card>
+          ) : filteredRequests.length === 0 ? (
             <Card>
               <CardContent className="p-8 text-center">
                 <AlertCircle className="w-12 h-12 text-gray-400 mx-auto mb-4" />
@@ -320,17 +282,10 @@ export default function ReservationRequestsPage() {
                 <CardContent className="p-6">
                   <div className="flex items-start justify-between mb-4">
                     <div className="flex-1">
-                      <div className="flex items-center space-x-3 mb-2">
+                      <div className="flex items-center gap-3 mb-2">
                         <h3 className="text-lg font-semibold text-gray-900">
-                          {request.title}
+                          {request.purpose || '회의'}
                         </h3>
-                        <Badge
-                          className={`text-xs border ${getPriorityColor(
-                            request.priority
-                          )}`}
-                        >
-                          {getPriorityLabel(request.priority)}
-                        </Badge>
                         <Badge
                           className={`text-xs ${getStatusColor(
                             request.status
@@ -338,35 +293,37 @@ export default function ReservationRequestsPage() {
                         >
                           {getStatusLabel(request.status)}
                         </Badge>
+                        <Badge variant="outline" className="text-xs">
+                          승인 필요
+                        </Badge>
                       </div>
 
-                      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4 text-sm text-gray-600">
-                        <div className="flex items-center space-x-2">
-                          <User className="w-4 h-4" />
+                      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 text-sm text-gray-600">
+                        <div className="flex items-center gap-2">
+                          <Calendar className="w-4 h-4" />
                           <span>
-                            {request.requester} ({request.department})
+                            {formatDateTime(request.startTime)} ~{' '}
+                            {formatDateTime(request.endTime)}
                           </span>
                         </div>
-                        <div className="flex items-center space-x-2">
-                          <MapPin className="w-4 h-4" />
-                          <span>{request.spaceName}</span>
-                        </div>
-                        <div className="flex items-center space-x-2">
-                          <Calendar className="w-4 h-4" />
-                          <span>{formatDate(request.date)}</span>
-                        </div>
-                        <div className="flex items-center space-x-2">
-                          <Clock className="w-4 h-4" />
+                        <div className="flex items-center gap-2">
+                          <User className="w-4 h-4" />
                           <span>
-                            {request.startTime} - {request.endTime} (
-                            {request.duration})
+                            {request.user?.name ?? `사용자 #${request.userId}`}
+                          </span>
+                        </div>
+                        <div className="flex items-center gap-2">
+                          <MapPin className="w-4 h-4" />
+                          <span>
+                            {request.space?.name ??
+                              `회의실 #${request.spaceId}`}
                           </span>
                         </div>
                       </div>
                     </div>
 
-                    {request.status === 'pending' && (
-                      <div className="flex space-x-2 ml-4">
+                    {request.status === 'PENDING' && (
+                      <div className="flex gap-2 ml-4">
                         <Button
                           size="sm"
                           onClick={() => handleApprove(request.id)}
@@ -394,14 +351,14 @@ export default function ReservationRequestsPage() {
                       <h4 className="text-sm font-medium text-gray-900 mb-1">
                         회의 목적
                       </h4>
-                      <p className="text-sm text-gray-700">{request.purpose}</p>
+                      <p className="text-sm text-gray-700">
+                        {request.purpose || '-'}
+                      </p>
                     </div>
 
                     <div className="flex items-center justify-between text-xs text-gray-500">
-                      <span>참석 예정: {request.attendees}명</span>
-                      <span>
-                        신청일시: {formatDateTime(request.requestedAt)}
-                      </span>
+                      <span>메모: {request.memo || '-'}</span>
+                      <span>신청일시: {formatDateTime(request.createdAt)}</span>
                     </div>
                   </div>
                 </CardContent>

--- a/placeit-frontend/src/components/dashboard/MeetingRoomCard.tsx
+++ b/placeit-frontend/src/components/dashboard/MeetingRoomCard.tsx
@@ -32,16 +32,24 @@ const AMENITY_MAP: Record<
   speaker: { label: '스피커', icon: Volume2 },
 };
 
+type RoomStatus =
+  | 'available'
+  | 'occupied'
+  | 'reserved'
+  | 'maintenance'
+  | 'unavailable'; // ← 추가
+
 interface MeetingRoomCardProps {
   name: string;
   description: string;
   capacity: number;
   features: string[];
-  status: 'available' | 'occupied' | 'reserved' | 'maintenance';
+  status: RoomStatus; // ← 타입에 포함
   imageUrl?: string;
   isSelected?: boolean;
   onSelect?: () => void;
   reservedTime?: string;
+  requiresApproval?: boolean;
 }
 
 export function MeetingRoomCard({
@@ -54,30 +62,32 @@ export function MeetingRoomCard({
   isSelected = false,
   onSelect,
   reservedTime,
+  requiresApproval = false,
 }: MeetingRoomCardProps) {
-  // 상수 정의
   const CARD_DIMENSIONS = {
     minHeight: 'min-h-[400px]',
     maxWidth: 'max-w-[280px]',
     imageHeight: 'h-48',
   } as const;
 
-  const getStatusColor = (status: string) => {
+  const getStatusColor = (status: RoomStatus) => {
     switch (status) {
       case 'available':
         return 'bg-green-500';
       case 'occupied':
-        return 'bg-red-500';
+        return 'bg-orange-600';
       case 'reserved':
-        return 'bg-orange-500';
+        return 'bg-amber-500';
       case 'maintenance':
         return 'bg-yellow-500';
+      case 'unavailable': // ← 추가
+        return 'bg-red-600';
       default:
         return 'bg-gray-500';
     }
   };
 
-  const getStatusText = (status: string) => {
+  const getStatusText = (status: RoomStatus) => {
     switch (status) {
       case 'available':
         return '사용 가능';
@@ -87,23 +97,28 @@ export function MeetingRoomCard({
         return '예약됨';
       case 'maintenance':
         return '점검 중';
+      case 'unavailable': // ← 추가
+        return '사용 불가능';
       default:
         return '알 수 없음';
     }
   };
 
+  const isClickable = status !== 'unavailable'; // 선택 막고 싶으면 사용
+
   return (
     <Card
       className={`w-full ${
         CARD_DIMENSIONS.maxWidth
-      } h-full hover:shadow-lg transition-all duration-200 cursor-pointer flex flex-col ${
-        CARD_DIMENSIONS.minHeight
-      } border-2 ${
+      } h-full hover:shadow-lg transition-all duration-200 ${
+        isClickable ? 'cursor-pointer' : 'cursor-not-allowed opacity-70'
+      } flex flex-col ${CARD_DIMENSIONS.minHeight} border-2 ${
         isSelected
           ? 'border-blue-500 shadow-xl bg-blue-50 ring-4 ring-blue-200'
           : 'border-gray-200 hover:border-blue-300 hover:bg-gray-50'
       }`}
-      onClick={onSelect}
+      onClick={isClickable ? onSelect : undefined}
+      aria-disabled={!isClickable}
     >
       <CardHeader className="relative pb-3">
         <div
@@ -126,7 +141,8 @@ export function MeetingRoomCard({
               }}
             />
           ) : null}
-          {/* 기본 이미지 플레이스홀더 (이미지가 없거나 로드 실패 시) */}
+
+          {/* 기본 이미지 플레이스홀더 */}
           <div
             className={`w-full h-full items-center justify-center ${
               imageUrl ? 'hidden' : 'flex'
@@ -139,6 +155,8 @@ export function MeetingRoomCard({
               <p className="text-blue-600 font-medium">{name}</p>
             </div>
           </div>
+
+          {/* 상태 뱃지 */}
           <Badge
             className={`absolute top-2 right-2 ${getStatusColor(
               status
@@ -147,6 +165,20 @@ export function MeetingRoomCard({
             {getStatusText(status)}
           </Badge>
         </div>
+
+        {/* 예약 정책 뱃지 */}
+        <div className="mb-2">
+          {requiresApproval ? (
+            <Badge className="bg-yellow-400 text-white text-xs px-2 py-1">
+              예약 시 승인 필요
+            </Badge>
+          ) : (
+            <Badge className="bg-blue-400 text-white text-xs px-2 py-1">
+              누구나 예약 가능
+            </Badge>
+          )}
+        </div>
+
         <CardTitle className="text-lg font-semibold">{name}</CardTitle>
         <CardDescription className="text-sm text-gray-600 mt-1">
           {description}

--- a/placeit-frontend/src/components/layout/Header.tsx
+++ b/placeit-frontend/src/components/layout/Header.tsx
@@ -112,8 +112,14 @@ export function Header() {
   const { user } = useUserStore();
   const { logout, loading } = useLogout({ redirectTo: '/login' });
 
+  const { list, currentId } = useWorkspaceStore();
+  const selected = list.find(w => w.id === currentId) ?? list[0];
+  const inviteCode = selected?.activeInvitationCode ?? '초대코드 없음';
+
   const handleCopy = () => {
-    navigator.clipboard.writeText('STARTUP2024');
+    if (inviteCode) {
+      navigator.clipboard.writeText(inviteCode);
+    }
   };
 
   return (
@@ -143,7 +149,7 @@ export function Header() {
           <WorkspaceToggle />
         </div>
 
-        {/* 오른쪽: 사용자/초대코드/로그아웃 - 기존 유지 */}
+        {/* 오른쪽: 사용자/초대코드/로그아웃 */}
         <div className="flex items-center gap-4 text-sm">
           <div className="flex items-center gap-2">
             <span
@@ -155,7 +161,7 @@ export function Header() {
             </span>
             <span className="text-gray-400">|</span>
             <div className="flex items-center">
-              <span className="text-blue-600">STARTUP2024</span>
+              <span className="text-blue-600">{inviteCode}</span>
               <Button
                 variant="ghost"
                 size="sm"

--- a/placeit-frontend/src/components/layout/Header.tsx
+++ b/placeit-frontend/src/components/layout/Header.tsx
@@ -26,6 +26,7 @@ function WorkspaceToggle() {
     hardRefresh,
     bindToUser,
   } = useWorkspaceStore();
+
   const selected = list.find(w => w.id === currentId) ?? list[0];
 
   React.useEffect(() => {
@@ -63,7 +64,7 @@ function WorkspaceToggle() {
           <ChevronsUpDown className="h-4 w-4 opacity-40" />
         </button>
 
-        {/* 필요할 때만 강제 새로고침(UX용) */}
+        {/* 필요할 때만 강제 새로고침(UX용)
         <button
           type="button"
           onClick={() => {
@@ -74,7 +75,7 @@ function WorkspaceToggle() {
           title="워크스페이스 목록 새로고침"
         >
           <RefreshCw className="h-4 w-4" />
-        </button>
+        </button> */}
       </div>
 
       {open && list.length > 0 && (
@@ -107,6 +108,17 @@ function WorkspaceToggle() {
   );
 }
 
+function isWorkspaceAdmin(workspaceRole?: string, globalRole?: string) {
+  const w = (workspaceRole ?? '').toUpperCase(); // 'SUPER_ADMIN' | 'ADMIN' | 'MEMBER' ...
+  const g = (globalRole ?? '').toUpperCase(); // 'admin' | 'user'
+  const adminSet = new Set(['ADMIN', 'SUPER_ADMIN']);
+  return adminSet.has(w) || adminSet.has(g);
+}
+
+function roleKoreanLabel(workspaceRole?: string, globalRole?: string) {
+  return isWorkspaceAdmin(workspaceRole, globalRole) ? '관리자' : '사용자';
+}
+
 export function Header() {
   const router = useRouter();
   const { user } = useUserStore();
@@ -115,6 +127,12 @@ export function Header() {
   const { list, currentId } = useWorkspaceStore();
   const selected = list.find(w => w.id === currentId) ?? list[0];
   const inviteCode = selected?.activeInvitationCode ?? '초대코드 없음';
+
+  const workspaceRole: string | undefined =
+    (selected as any)?.userRole ?? (selected as any)?.role ?? undefined;
+
+  const isAdmin = isWorkspaceAdmin(workspaceRole, user?.role);
+  const roleLabel = roleKoreanLabel(workspaceRole, user?.role);
 
   const handleCopy = () => {
     if (inviteCode) {
@@ -152,12 +170,8 @@ export function Header() {
         {/* 오른쪽: 사용자/초대코드/로그아웃 */}
         <div className="flex items-center gap-4 text-sm">
           <div className="flex items-center gap-2">
-            <span
-              className={`${
-                user?.role === 'admin' ? 'text-red-600' : 'text-blue-600'
-              }`}
-            >
-              {user?.name} ({user?.role === 'admin' ? '관리자' : '사용자'})
+            <span className={`${isAdmin ? 'text-red-600' : 'text-blue-600'}`}>
+              {user?.name} ({roleLabel})
             </span>
             <span className="text-gray-400">|</span>
             <div className="flex items-center">

--- a/placeit-frontend/src/components/layout/Sidebar.tsx
+++ b/placeit-frontend/src/components/layout/Sidebar.tsx
@@ -465,7 +465,7 @@ export function Sidebar({ activePage, userName = '홍길동' }: SidebarProps) {
         {/* 여백을 채우는 div */}
         <div className="flex-1"></div>
 
-        {/* 설정 - 하단 고정 */}
+        {/* 설정 - 하단 고정
         <div className="mt-auto">
           <Link
             href="/settings"
@@ -477,7 +477,7 @@ export function Sidebar({ activePage, userName = '홍길동' }: SidebarProps) {
               <div className="text-xs text-gray-500">프로필 설정</div>
             </div>
           </Link>
-        </div>
+        </div> */}
       </div>
     </aside>
   );

--- a/placeit-frontend/src/components/layout/Sidebar.tsx
+++ b/placeit-frontend/src/components/layout/Sidebar.tsx
@@ -12,7 +12,6 @@ import {
   Users,
   Settings,
   FileText,
-  Shield,
   Building2,
   type LucideIcon,
 } from 'lucide-react';
@@ -21,6 +20,7 @@ import { usePathname } from 'next/navigation';
 import { fetchMyWorkspaces } from '@/services/workspaces';
 import { fetchWorkspaceUsers } from '@/services/workspaceUsers';
 import { fetchWorkspaceRooms } from '@/services/meetingRooms';
+import { fetchWorkspaceReservations } from '@/services/reservations';
 import { useWorkspaceStore } from '@/stores/workspaceStore';
 
 interface SidebarProps {
@@ -60,6 +60,8 @@ export function Sidebar({ activePage, userName = '홍길동' }: SidebarProps) {
   const [workspaceCount, setWorkspaceCount] = useState<number>(0);
   const [userCount, setUserCount] = useState<number>(0);
   const [roomCount, setRoomCount] = useState<number>(0);
+  const [approvedCount, setApprovedCount] = useState<number>(0);
+  const [pendingCount, setPendingCount] = useState<number>(0);
 
   const pathname = usePathname();
   const normalize = (p: string) => (p.endsWith('/') ? p.slice(0, -1) : p);
@@ -76,6 +78,42 @@ export function Sidebar({ activePage, userName = '홍길동' }: SidebarProps) {
     }
     return [];
   };
+
+  // 예약 개수 가져오기
+  useEffect(() => {
+    if (!currentId) {
+      setApprovedCount(0);
+      return;
+    }
+    (async () => {
+      try {
+        const res = await fetchWorkspaceReservations(Number(currentId));
+        const approved = res.filter((r: any) => r.status === 'APPROVED');
+        setApprovedCount(approved.length);
+      } catch (e) {
+        console.error('예약 불러오기 실패:', e);
+        setApprovedCount(0);
+      }
+    })();
+  }, [currentId]);
+
+  // 요청 개수 가져오기
+  useEffect(() => {
+    if (!currentId) {
+      setPendingCount(0);
+      return;
+    }
+    (async () => {
+      try {
+        const res = await fetchWorkspaceReservations(Number(currentId));
+        const pending = res.filter((r: any) => r.status === 'PENDING');
+        setPendingCount(pending.length);
+      } catch (e) {
+        console.error('예약 불러오기 실패:', e);
+        setPendingCount(0);
+      }
+    })();
+  }, [currentId]);
 
   // 워크스페이스 개수 가져오기
   useEffect(() => {
@@ -141,10 +179,10 @@ export function Sidebar({ activePage, userName = '홍길동' }: SidebarProps) {
     {
       id: 'reservations',
       label: '예약 관리',
-      subtitle: '5건의 예약',
+      subtitle: `${approvedCount}건의 예약`,
       icon: Calendar,
       href: '/reservations',
-      badge: '5',
+      badge: approvedCount > 0 ? String(approvedCount) : null,
       subItems: [
         {
           id: 'reservation-status',
@@ -210,7 +248,7 @@ export function Sidebar({ activePage, userName = '홍길동' }: SidebarProps) {
       label: '오늘 예약',
       subtitle: `${currentMonth}월 ${currentDay}일 예약 현황`,
       icon: Calendar,
-      badge: '2건',
+      badge: `${approvedCount}건`,
       badgeColor: 'bg-blue-500',
       bgColor: 'bg-blue-50',
     },
@@ -219,7 +257,7 @@ export function Sidebar({ activePage, userName = '홍길동' }: SidebarProps) {
       label: '대기 중',
       subtitle: '승인이 필요한 예약이 있습니다',
       icon: FileText,
-      badge: '2건',
+      badge: `${pendingCount}건`,
       badgeColor: 'bg-orange-500',
       bgColor: 'bg-orange-50',
     },
@@ -230,10 +268,6 @@ export function Sidebar({ activePage, userName = '홍길동' }: SidebarProps) {
       <div className="p-6 pt-8 flex flex-col h-full">
         {/* 워크스페이스 섹션 */}
         <div className="mb-8">
-          <h2 className="text-xl font-bold text-gray-900 mb-6 tracking-tight">
-            애플
-          </h2>
-
           {/* 사용자 정보 */}
           <div className="flex items-center gap-3 p-4 bg-gradient-to-r from-gray-50 to-gray-100 rounded-xl border border-gray-200 mb-6 shadow-sm">
             <div
@@ -251,7 +285,9 @@ export function Sidebar({ activePage, userName = '홍길동' }: SidebarProps) {
               <div className="font-semibold text-sm text-gray-900">
                 {userName}
               </div>
-              <div className="text-xs text-gray-600">admin@company.com</div>
+              <div className="text-xs text-gray-600">
+                {user?.email ?? 'no-email@example.com'}
+              </div>
             </div>
           </div>
 

--- a/placeit-frontend/src/components/layout/Sidebar.tsx
+++ b/placeit-frontend/src/components/layout/Sidebar.tsx
@@ -264,7 +264,7 @@ export function Sidebar({ activePage, userName = '홍길동' }: SidebarProps) {
   ] as const;
 
   return (
-    <aside className="w-64 bg-white text-gray-900 h-full overflow-y-auto relative border-r border-gray-200 min-w-64">
+    <aside className="w-76 bg-white text-gray-900 h-full overflow-y-auto relative border-r border-gray-200 min-w-64">
       <div className="p-6 pt-8 flex flex-col h-full">
         {/* 워크스페이스 섹션 */}
         <div className="mb-8">

--- a/placeit-frontend/src/components/reservation/ReservationModal.tsx
+++ b/placeit-frontend/src/components/reservation/ReservationModal.tsx
@@ -17,6 +17,7 @@ import { Building, Users } from 'lucide-react';
 import { DurationSelector } from './DurationSelector';
 import { ReservationSummary } from './ReservationSummary';
 import { TimeSelectionGrid } from './TimeSelectionGrid';
+import { createReservation } from '@/services/reservations';
 
 interface ReservationModalProps {
   isOpen: boolean;
@@ -25,13 +26,13 @@ interface ReservationModalProps {
   onAddReservation?: (newReservation: any) => void;
   onTimeChange?: (time: string) => void;
   room: {
-    id: string;
+    id: number | string;
     name: string;
     description: string;
     capacity: number;
     features: string[];
     reservedTime?: string;
-  };
+  } | null;
   selectedDate?: Date;
   selectedTime?: string;
   timeSlots: string[];
@@ -46,6 +47,48 @@ interface ReservationModalProps {
   }>;
 }
 
+// '2025-09-16T09:00:00+09:00' 형태로 조합
+function toKstIso(date: Date, timeHHmm: string) {
+  const [hh, mm] = timeHHmm.split(':').map(n => parseInt(n, 10));
+  const local = new Date(date);
+  local.setHours(hh, mm, 0, 0);
+
+  // KST 고정 오프셋(+09:00) 문자열로 구성
+  const yyyy = local.getFullYear();
+  const MM = String(local.getMonth() + 1).padStart(2, '0');
+  const dd = String(local.getDate()).padStart(2, '0');
+  const HH = String(local.getHours()).padStart(2, '0');
+  const m = String(local.getMinutes()).padStart(2, '0');
+  return `${yyyy}-${MM}-${dd}T${HH}:${m}:00+09:00`;
+}
+
+function durationToMinutes(duration: string) {
+  // '30분' | '1시간' | '2시간' | '90분' 등 처리
+  if (duration.includes('시간')) {
+    const num = parseInt(duration.replace('시간', '').trim(), 10);
+    return isNaN(num) ? 60 : num * 60;
+  }
+  if (duration.includes('분')) {
+    const num = parseInt(duration.replace('분', '').trim(), 10);
+    return isNaN(num) ? 30 : num;
+  }
+  // 기본값 30분
+  return 30;
+}
+
+function addMinutesToIso(iso: string, addMin: number) {
+  // iso는 +09:00 오프셋 문자열. Date 파싱 → 분 추가 → 다시 +09:00으로 출력
+  const d = new Date(iso);
+  d.setMinutes(d.getMinutes() + addMin);
+
+  const yyyy = d.getFullYear();
+  const MM = String(d.getMonth() + 1).padStart(2, '0');
+  const dd = String(d.getDate()).padStart(2, '0');
+  const HH = String(d.getHours()).padStart(2, '0');
+  const m = String(d.getMinutes()).padStart(2, '0');
+  return `${yyyy}-${MM}-${dd}T${HH}:${m}:00+09:00`;
+}
+
 export function ReservationModal({
   isOpen,
   onClose,
@@ -57,6 +100,7 @@ export function ReservationModal({
   timeSlots,
   existingReservations = [],
 }: ReservationModalProps) {
+  const [submitting, setSubmitting] = useState(false);
   const [formData, setFormData] = useState({
     title: '',
     attendees: '',
@@ -80,50 +124,62 @@ export function ReservationModal({
     }));
   };
 
-  const handleSubmit = (e: React.FormEvent) => {
+  const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
 
-    // 예약 정보 검증
+    if (!room) {
+      alert('회의실을 선택해주세요.');
+      return;
+    }
+    if (!selectedDate) {
+      alert('날짜를 선택해주세요.');
+      return;
+    }
+    if (!formData.selectedTime) {
+      alert('시간을 선택해주세요.');
+      return;
+    }
     if (!formData.title.trim()) {
       alert('회의 제목을 입력해주세요.');
       return;
     }
 
-    // 예약 정보 생성 (로컬 시간 기준)
-    const reservationData = {
-      room: room.name,
-      date: selectedDate
-        ? `${selectedDate.getFullYear()}-${String(
-            selectedDate.getMonth() + 1
-          ).padStart(2, '0')}-${String(selectedDate.getDate()).padStart(
-            2,
-            '0'
-          )}`
-        : '',
-      time: formData.selectedTime,
-      title: formData.title,
-      attendees: formData.attendees,
-      notes: formData.notes,
-    };
+    try {
+      setSubmitting(true);
 
-    // onAddReservation 콜백이 있으면 호출
-    if (onAddReservation) {
-      onAddReservation(reservationData);
-    } else {
-      console.log('예약 정보:', reservationData);
-      alert('예약이 완료되었습니다!');
+      const startIso = toKstIso(selectedDate, formData.selectedTime);
+      const endIso = addMinutesToIso(
+        startIso,
+        durationToMinutes(formData.duration)
+      );
+
+      const payload = {
+        spaceId: Number(room.id),
+        startTime: startIso,
+        endTime: endIso,
+        purpose: formData.title, // 제목 → purpose
+        attendees: formData.attendees, // 문자열 그대로
+        memo: formData.notes,
+      };
+
+      const created = await createReservation(payload);
+
+      // 상위에 알려 로컬 갱신(선택)
+      if (onAddReservation) {
+        onAddReservation(created);
+      }
+
+      alert('예약 요청이 등록되었습니다.');
+      handleClose();
+    } catch (err: any) {
+      const msg =
+        err?.response?.data?.message ||
+        err?.message ||
+        '예약 요청 중 오류가 발생했습니다.';
+      alert(msg);
+    } finally {
+      setSubmitting(false);
     }
-
-    // 폼 초기화
-    setFormData({
-      title: '',
-      attendees: '',
-      notes: '',
-      selectedTime: selectedTime || '',
-      duration: '30분',
-    });
-
-    onClose();
   };
 
   const handleClose = () => {
@@ -138,18 +194,14 @@ export function ReservationModal({
     onClose();
   };
 
-  // 예약된 시간인지 확인하는 함수
+  // 예약된 시간인지 확인하는 함수 (room.reservedTime 형식: '09:00-10:00')
   const isTimeReserved = (time: string) => {
-    if (!room.reservedTime) return false;
-
+    if (!room?.reservedTime) return false;
     const [startTime, endTime] = room.reservedTime.split('-');
     return time >= startTime && time < endTime;
   };
 
-  // room이 null인 경우 모달을 렌더링하지 않음
-  if (!room) {
-    return null;
-  }
+  if (!room) return null;
 
   return (
     <Dialog open={isOpen} onOpenChange={handleClose}>
@@ -212,10 +264,7 @@ export function ReservationModal({
             selectedTime={formData.selectedTime}
             onTimeSelect={time => {
               setFormData(prev => ({ ...prev, selectedTime: time }));
-              // 상위 컴포넌트에도 시간 변경 알림
-              if (onTimeChange) {
-                onTimeChange(time);
-              }
+              if (onTimeChange) onTimeChange(time);
             }}
             isTimeReserved={isTimeReserved}
             showLegend={false}
@@ -247,7 +296,7 @@ export function ReservationModal({
                 name="attendees"
                 value={formData.attendees}
                 onChange={handleInputChange}
-                placeholder="참석자 이름을 입력하세요"
+                placeholder="참석자 이름을 입력하세요 (쉼표로 구분)"
                 className="mt-1"
               />
             </div>
@@ -276,10 +325,17 @@ export function ReservationModal({
           </div>
 
           <DialogFooter>
-            <Button type="button" variant="outline" onClick={handleClose}>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={handleClose}
+              disabled={submitting}
+            >
               취소
             </Button>
-            <Button type="submit">예약하기</Button>
+            <Button type="submit" disabled={submitting}>
+              {submitting ? '예약 중…' : '예약하기'}
+            </Button>
           </DialogFooter>
         </form>
       </DialogContent>

--- a/placeit-frontend/src/components/reservation/ReservationModal.tsx
+++ b/placeit-frontend/src/components/reservation/ReservationModal.tsx
@@ -374,14 +374,14 @@ export function ReservationModal({
 
             <div>
               <Label htmlFor="notes" className="text-sm font-medium">
-                메모
+                설명
               </Label>
               <Input
                 id="notes"
                 name="notes"
                 value={formData.notes}
                 onChange={handleInputChange}
-                placeholder="추가 메모를 입력하세요"
+                placeholder="회의 목적이나 주요 안건을 간단히 입력하세요"
                 className="mt-1"
               />
             </div>

--- a/placeit-frontend/src/components/reservation/ReservationModal.tsx
+++ b/placeit-frontend/src/components/reservation/ReservationModal.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import {
   Dialog,
   DialogContent,
@@ -17,14 +17,32 @@ import { Building, Users } from 'lucide-react';
 import { DurationSelector } from './DurationSelector';
 import { ReservationSummary } from './ReservationSummary';
 import { TimeSelectionGrid } from './TimeSelectionGrid';
-import { createReservation } from '@/services/reservations';
+import { createReservation, updateReservation } from '@/services/reservations';
 
 interface ReservationModalProps {
   isOpen: boolean;
   onClose: () => void;
+
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   onAddReservation?: (newReservation: any) => void;
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  onUpdateReservation?: (updated: any) => void;
+
+  mode?: 'create' | 'edit';
+
+  editingReservation?: {
+    id: string | number;
+    date: string;
+    time: string;
+    endTime?: string;
+    title: string;
+    attendees?: string;
+    notes?: string;
+  };
+
   onTimeChange?: (time: string) => void;
+
   room: {
     id: number | string;
     name: string;
@@ -33,9 +51,11 @@ interface ReservationModalProps {
     features: string[];
     reservedTime?: string;
   } | null;
+
   selectedDate?: Date;
   selectedTime?: string;
   timeSlots: string[];
+
   existingReservations?: Array<{
     id: string;
     title: string;
@@ -47,13 +67,11 @@ interface ReservationModalProps {
   }>;
 }
 
-// '2025-09-16T09:00:00+09:00' 형태로 조합
 function toKstIso(date: Date, timeHHmm: string) {
   const [hh, mm] = timeHHmm.split(':').map(n => parseInt(n, 10));
   const local = new Date(date);
   local.setHours(hh, mm, 0, 0);
 
-  // KST 고정 오프셋(+09:00) 문자열로 구성
   const yyyy = local.getFullYear();
   const MM = String(local.getMonth() + 1).padStart(2, '0');
   const dd = String(local.getDate()).padStart(2, '0');
@@ -63,7 +81,6 @@ function toKstIso(date: Date, timeHHmm: string) {
 }
 
 function durationToMinutes(duration: string) {
-  // '30분' | '1시간' | '2시간' | '90분' 등 처리
   if (duration.includes('시간')) {
     const num = parseInt(duration.replace('시간', '').trim(), 10);
     return isNaN(num) ? 60 : num * 60;
@@ -72,12 +89,10 @@ function durationToMinutes(duration: string) {
     const num = parseInt(duration.replace('분', '').trim(), 10);
     return isNaN(num) ? 30 : num;
   }
-  // 기본값 30분
   return 30;
 }
 
 function addMinutesToIso(iso: string, addMin: number) {
-  // iso는 +09:00 오프셋 문자열. Date 파싱 → 분 추가 → 다시 +09:00으로 출력
   const d = new Date(iso);
   d.setMinutes(d.getMinutes() + addMin);
 
@@ -93,7 +108,10 @@ export function ReservationModal({
   isOpen,
   onClose,
   onAddReservation,
+  onUpdateReservation,
   onTimeChange,
+  mode = 'create',
+  editingReservation,
   room,
   selectedDate,
   selectedTime,
@@ -109,12 +127,45 @@ export function ReservationModal({
     duration: '30분',
   });
 
-  // selectedTime이 변경될 때 formData도 동기화
-  React.useEffect(() => {
-    if (selectedTime) {
+  useEffect(() => {
+    if (!isOpen) return;
+
+    if (mode === 'edit' && editingReservation) {
+      const calcDuration = () => {
+        const s = editingReservation.time;
+        const e = editingReservation.endTime;
+        if (!s || !e) return '30분';
+        const [sh, sm] = s.split(':').map(Number);
+        const [eh, em] = e.split(':').map(Number);
+        const delta = eh * 60 + em - (sh * 60 + sm);
+        return delta % 60 === 0 ? `${delta / 60}시간` : `${delta}분`;
+      };
+
+      setFormData({
+        title: editingReservation.title ?? '',
+        attendees: editingReservation.attendees ?? '',
+        notes: editingReservation.notes ?? '',
+        selectedTime: editingReservation.time ?? '',
+        duration: calcDuration(),
+      });
+
+      if (editingReservation.time) onTimeChange?.(editingReservation.time);
+    } else {
+      // create 모드: selectedTime 반영
+      setFormData(prev => ({
+        ...prev,
+        selectedTime: selectedTime || '',
+        duration: '30분',
+      }));
+    }
+  }, [isOpen, mode, editingReservation, selectedTime, onTimeChange]);
+
+  // create 모드에서 외부 selectedTime이 바뀌면 동기화
+  useEffect(() => {
+    if (mode !== 'edit' && selectedTime) {
       setFormData(prev => ({ ...prev, selectedTime }));
     }
-  }, [selectedTime]);
+  }, [selectedTime, mode]);
 
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { name, value } = e.target;
@@ -124,58 +175,63 @@ export function ReservationModal({
     }));
   };
 
+  // 제출
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
 
-    if (!room) {
-      alert('회의실을 선택해주세요.');
-      return;
-    }
-    if (!selectedDate) {
-      alert('날짜를 선택해주세요.');
-      return;
-    }
-    if (!formData.selectedTime) {
-      alert('시간을 선택해주세요.');
-      return;
-    }
-    if (!formData.title.trim()) {
-      alert('회의 제목을 입력해주세요.');
-      return;
-    }
+    if (!room) return alert('회의실을 선택해주세요.');
+    if (!formData.selectedTime) return alert('시간을 선택해주세요.');
+    if (!formData.title.trim()) return alert('회의 제목을 입력해주세요.');
+
+    // 기준 날짜: edit 모드면 editingReservation.date 사용
+    const baseDate =
+      mode === 'edit' && editingReservation
+        ? (() => {
+            const [y, m, d] = editingReservation.date.split('-').map(Number);
+            return new Date(y, (m || 1) - 1, d || 1);
+          })()
+        : selectedDate;
+
+    if (!baseDate) return alert('날짜를 선택해주세요.');
 
     try {
       setSubmitting(true);
 
-      const startIso = toKstIso(selectedDate, formData.selectedTime);
+      const startIso = toKstIso(baseDate, formData.selectedTime);
       const endIso = addMinutesToIso(
         startIso,
         durationToMinutes(formData.duration)
       );
 
       const payload = {
-        spaceId: Number(room.id),
         startTime: startIso,
         endTime: endIso,
-        purpose: formData.title, // 제목 → purpose
-        attendees: formData.attendees, // 문자열 그대로
+        purpose: formData.title,
+        attendees: formData.attendees,
         memo: formData.notes,
       };
 
-      const created = await createReservation(payload);
-
-      // 상위에 알려 로컬 갱신(선택)
-      if (onAddReservation) {
-        onAddReservation(created);
+      if (mode === 'edit' && editingReservation?.id != null) {
+        const updated = await updateReservation(editingReservation.id, payload);
+        onUpdateReservation?.(updated);
+        alert('예약이 수정되었습니다.');
+        handleClose();
+      } else {
+        const created = await createReservation({
+          spaceId: Number(room.id),
+          ...payload,
+        });
+        onAddReservation?.(created);
+        alert('예약 요청이 등록되었습니다.');
+        handleClose();
       }
-
-      alert('예약 요청이 등록되었습니다.');
-      handleClose();
     } catch (err: any) {
       const msg =
         err?.response?.data?.message ||
         err?.message ||
-        '예약 요청 중 오류가 발생했습니다.';
+        (mode === 'edit'
+          ? '예약 수정 중 오류가 발생했습니다.'
+          : '예약 요청 중 오류가 발생했습니다.');
       alert(msg);
     } finally {
       setSubmitting(false);
@@ -183,7 +239,6 @@ export function ReservationModal({
   };
 
   const handleClose = () => {
-    // 폼 초기화
     setFormData({
       title: '',
       attendees: '',
@@ -194,7 +249,7 @@ export function ReservationModal({
     onClose();
   };
 
-  // 예약된 시간인지 확인하는 함수 (room.reservedTime 형식: '09:00-10:00')
+  // 예약된 시간인지 확인
   const isTimeReserved = (time: string) => {
     if (!room?.reservedTime) return false;
     const [startTime, endTime] = room.reservedTime.split('-');
@@ -203,16 +258,32 @@ export function ReservationModal({
 
   if (!room) return null;
 
+  /** 요약에 표시할 날짜/시간(수정 모드면 editing 값 우선) */
+  const summaryDate: Date | undefined =
+    mode === 'edit' && editingReservation
+      ? (() => {
+          const [y, m, d] = editingReservation.date.split('-').map(Number);
+          return new Date(y, (m || 1) - 1, d || 1);
+        })()
+      : selectedDate;
+
+  const summaryTime =
+    mode === 'edit' && editingReservation
+      ? editingReservation.time
+      : formData.selectedTime || selectedTime;
+
   return (
     <Dialog open={isOpen} onOpenChange={handleClose}>
       <DialogContent className="sm:max-w-md max-h-[90vh] overflow-y-auto">
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
             <Building className="h-5 w-5 text-blue-600" />
-            회의실 예약
+            {mode === 'edit' ? '예약 수정' : '회의실 예약'}
           </DialogTitle>
           <DialogDescription>
-            회의실 예약을 위한 정보를 입력해주세요.
+            {mode === 'edit'
+              ? '예약 정보를 수정합니다.'
+              : '회의실 예약을 위한 정보를 입력해주세요.'}
           </DialogDescription>
         </DialogHeader>
 
@@ -220,12 +291,12 @@ export function ReservationModal({
           {/* 예약 정보 요약 */}
           <ReservationSummary
             room={room}
-            selectedDate={selectedDate}
-            selectedTime={formData.selectedTime || selectedTime}
+            selectedDate={summaryDate}
+            selectedTime={summaryTime}
           />
 
           {/* 기존 예약 정보 */}
-          {existingReservations.length > 0 && (
+          {mode !== 'edit' && existingReservations.length > 0 && (
             <div>
               <Label className="text-sm font-medium text-gray-700">
                 해당 날짜의 기존 예약
@@ -264,7 +335,7 @@ export function ReservationModal({
             selectedTime={formData.selectedTime}
             onTimeSelect={time => {
               setFormData(prev => ({ ...prev, selectedTime: time }));
-              if (onTimeChange) onTimeChange(time);
+              onTimeChange?.(time);
             }}
             isTimeReserved={isTimeReserved}
             showLegend={false}
@@ -334,7 +405,13 @@ export function ReservationModal({
               취소
             </Button>
             <Button type="submit" disabled={submitting}>
-              {submitting ? '예약 중…' : '예약하기'}
+              {submitting
+                ? mode === 'edit'
+                  ? '수정 중…'
+                  : '예약 중…'
+                : mode === 'edit'
+                ? '수정하기'
+                : '예약하기'}
             </Button>
           </DialogFooter>
         </form>

--- a/placeit-frontend/src/components/reservation/ReservationSummary.tsx
+++ b/placeit-frontend/src/components/reservation/ReservationSummary.tsx
@@ -5,7 +5,7 @@ import { Calendar, Clock, Building, Users } from 'lucide-react';
 
 interface ReservationSummaryProps {
   room: {
-    id: string;
+    id: string | number;
     name: string;
     description: string;
     capacity: number;

--- a/placeit-frontend/src/components/reservation/ReservationSummary.tsx
+++ b/placeit-frontend/src/components/reservation/ReservationSummary.tsx
@@ -28,6 +28,11 @@ export function ReservationSummary({
         <span>{room.name}</span>
       </div>
       <div className="flex items-center gap-2 text-sm">
+        <Users className="h-4 w-4 text-gray-600" />
+        <span className="font-medium">수용 인원:</span>
+        <span>{room.capacity}명</span>
+      </div>
+      <div className="flex items-center gap-2 text-sm">
         <Calendar className="h-4 w-4 text-gray-600" />
         <span className="font-medium">날짜:</span>
         <span>
@@ -43,11 +48,6 @@ export function ReservationSummary({
         <Clock className="h-4 w-4 text-gray-600" />
         <span className="font-medium">시간:</span>
         <span>{selectedTime}</span>
-      </div>
-      <div className="flex items-center gap-2 text-sm">
-        <Users className="h-4 w-4 text-gray-600" />
-        <span className="font-medium">수용 인원:</span>
-        <span>{room.capacity}명</span>
       </div>
     </div>
   );

--- a/placeit-frontend/src/components/ui/switch.tsx
+++ b/placeit-frontend/src/components/ui/switch.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+import * as React from 'react';
+import * as SwitchPrimitives from '@radix-ui/react-switch';
+import { cn } from '@/lib/utils';
+
+export interface SwitchProps
+  extends React.ComponentPropsWithoutRef<typeof SwitchPrimitives.Root> {
+  checked?: boolean;
+  onCheckedChange?: (checked: boolean) => void;
+}
+
+const Switch = React.forwardRef<
+  React.ElementRef<typeof SwitchPrimitives.Root>,
+  SwitchProps
+>(({ className, checked, onCheckedChange, ...props }, ref) => (
+  <SwitchPrimitives.Root
+    ref={ref}
+    checked={checked}
+    onCheckedChange={onCheckedChange}
+    className={cn(
+      'peer inline-flex h-6 w-11 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors',
+      checked ? 'bg-gray-900' : 'bg-gray-200',
+      className
+    )}
+    {...props}
+  >
+    <SwitchPrimitives.Thumb
+      className={cn(
+        'pointer-events-none block h-5 w-5 rounded-full bg-white shadow-lg ring-0 transition-transform',
+        checked ? 'translate-x-5' : 'translate-x-0'
+      )}
+    />
+  </SwitchPrimitives.Root>
+));
+Switch.displayName = 'Switch';
+
+export { Switch };

--- a/placeit-frontend/src/lib/workspaceId.ts
+++ b/placeit-frontend/src/lib/workspaceId.ts
@@ -1,0 +1,55 @@
+import { useEffect } from 'react';
+import { useWorkspaceStore } from '@/stores/workspaceStore';
+
+/** 동기적으로 현재 워크스페이스 ID를 반환 (없을 수 있음) */
+export function getActiveWorkspaceIdSync(): number | null {
+  const id = useWorkspaceStore.getState().currentId;
+  return id != null ? Number(id) : null;
+}
+
+/**
+ * 비동기 보장형: 없으면 내부적으로 refreshIfStale()를 1회 시도하고
+ * 그래도 없으면 에러를 던짐.
+ */
+export async function ensureActiveWorkspaceId(): Promise<number> {
+  const store = useWorkspaceStore.getState();
+
+  if (store.currentId != null) return Number(store.currentId);
+
+  // 바인딩(ownerKey)이 되어있는 상황이라면 최신 목록을 가져와 currentId 자동 세팅 유도
+  // (store 구현상 refreshIfStale() 호출 시 list 채우고 currentId 미설정이면 첫 번째로 세팅됨)
+  await store.refreshIfStale?.();
+
+  const after = useWorkspaceStore.getState().currentId;
+  if (after == null) {
+    throw new Error('NO_ACTIVE_WORKSPACE');
+  }
+  return Number(after);
+}
+
+/**
+ * React 컴포넌트에서 쓰기 위한 훅:
+ * - 현재 ID를 number | null 로 반환
+ * - 옵션에 따라 currentId가 없을 때 refreshIfStale()를 알아서 1회 시도
+ */
+export function useActiveWorkspaceId(opts: { autofetch?: boolean } = {}) {
+  const { autofetch = true } = opts;
+  const currentId = useWorkspaceStore(s => s.currentId);
+  const refreshIfStale = useWorkspaceStore(s => s.refreshIfStale);
+
+  useEffect(() => {
+    if (!autofetch) return;
+    if (currentId == null) {
+      // ownerKey가 바인딩되어 있다면 내부에서 리스트/아이디를 세팅해줄 것
+      refreshIfStale?.().catch(() => {});
+    }
+  }, [autofetch, currentId, refreshIfStale]);
+
+  return currentId != null ? Number(currentId) : null;
+}
+
+/** 방어적 변환기: undefined/null/NaN 모두 걸러냄 */
+export function toWsId(input: unknown): number | null {
+  const n = Number(input);
+  return Number.isFinite(n) ? n : null;
+}

--- a/placeit-frontend/src/services/reservations.ts
+++ b/placeit-frontend/src/services/reservations.ts
@@ -50,6 +50,14 @@ export type ApiReservation = {
   };
 };
 
+export type UpdateReservationBody = {
+  startTime: string;
+  endTime: string;
+  purpose: string;
+  attendees?: string;
+  memo?: string;
+};
+
 // 예약 생성
 export async function createReservation(body: CreateReservationBody) {
   const { data } = await api.post<Reservation>('/reservations', body);
@@ -63,4 +71,18 @@ export async function fetchWorkspaceReservations(workspaceId: number) {
     total: number;
   }>(`/workspaces/${workspaceId}/reservations`);
   return data.reservations;
+}
+
+// 예약 삭제
+export async function deleteReservation(id: string | number): Promise<void> {
+  await api.delete(`/reservations/${id}`);
+}
+
+// 예약 수정
+export async function updateReservation(
+  id: string | number,
+  body: UpdateReservationBody
+) {
+  const { data } = await api.patch(`/reservations/${id}`, body);
+  return data;
 }

--- a/placeit-frontend/src/services/reservations.ts
+++ b/placeit-frontend/src/services/reservations.ts
@@ -1,0 +1,66 @@
+import { api } from '@/lib/axios';
+
+export interface CreateReservationBody {
+  spaceId: number;
+  startTime: string; // ISO
+  endTime: string; // ISO
+  purpose: string; // 제목
+  attendees?: string;
+  memo?: string;
+}
+
+export interface Reservation {
+  id: number;
+  spaceId: number;
+  userId: number;
+  attendees: string;
+  memo: string;
+  startTime: string;
+  endTime: string;
+  status: 'PENDING' | 'APPROVED' | 'REJECTED';
+  purpose: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export type ApiReservation = {
+  id: number;
+  spaceId: number;
+  userId: number;
+  attendees: string;
+  memo: string;
+  startTime: string;
+  endTime: string;
+  status: 'PENDING' | 'APPROVED' | 'REJECTED';
+  purpose: string;
+  createdAt: string;
+  updatedAt: string;
+  space: {
+    id: number;
+    name: string;
+    capacity: number;
+    description: string;
+    amenities: string[];
+    isActive: boolean;
+  };
+  user: {
+    id: number;
+    name: string;
+    email: string;
+  };
+};
+
+// 예약 생성
+export async function createReservation(body: CreateReservationBody) {
+  const { data } = await api.post<Reservation>('/reservations', body);
+  return data;
+}
+
+// 예약 조회
+export async function fetchWorkspaceReservations(workspaceId: number) {
+  const { data } = await api.get<{
+    reservations: ApiReservation[];
+    total: number;
+  }>(`/workspaces/${workspaceId}/reservations`);
+  return data.reservations;
+}

--- a/placeit-frontend/src/services/spaces.ts
+++ b/placeit-frontend/src/services/spaces.ts
@@ -5,6 +5,8 @@ export interface Space {
   workspaceId: number;
   name: string;
   description: string;
+  isActive: boolean;
+  requiresApproval: boolean;
   capacity: number;
   amenities: string[];
 }

--- a/placeit-frontend/src/stores/reservationStore.ts
+++ b/placeit-frontend/src/stores/reservationStore.ts
@@ -3,6 +3,17 @@ import { persist } from 'zustand/middleware';
 import { Reservation, CalendarView, MeetingRoom } from '@/types';
 import { sampleRooms } from '@/data/sampleData';
 
+type RequiredFields = Pick<Reservation, 'title' | 'room' | 'date' | 'time'>;
+
+function genId() {
+  return `${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
+}
+
+function dedupeKey(r: Reservation) {
+  // 같은 예약의 고유성: (id || ""), date, time
+  return `${r.id ?? ''}-${r.date}-${r.time}`;
+}
+
 interface ReservationStore {
   // 상태
   reservations: Reservation[];
@@ -14,12 +25,24 @@ interface ReservationStore {
   loading: boolean;
 
   // 액션
-  addReservation: (reservation: Omit<Reservation, 'id'>) => Promise<boolean>;
+  /** 단건 추가 (id가 있으면 보존, 없으면 생성) */
+  addReservation: (
+    reservationData: Partial<Reservation> & RequiredFields
+  ) => Promise<boolean>;
+
   updateReservation: (
     id: string,
     updates: Partial<Reservation>
   ) => Promise<boolean>;
+
   deleteReservation: (id: string) => Promise<boolean>;
+
+  /** 예약을 통째로 교체(일반적으로 API 동기화 시 사용) */
+  setReservations: (items: Reservation[]) => void;
+
+  /** 필요 시 전체 초기화 */
+  clearReservations: () => void;
+
   setSelectedDate: (date: Date | null) => void;
   setCurrentView: (view: CalendarView) => void;
   updateRoomStatus: (roomId: string, status: MeetingRoom['status']) => void;
@@ -53,20 +76,33 @@ export const useReservationStore = create<ReservationStore>()(
       error: null,
       loading: false,
 
-      // 예약 추가
+      // 예약 추가 (id 보존)
       addReservation: async reservationData => {
         try {
           set({ loading: true, error: null });
 
-          const newReservation: Reservation = {
-            ...reservationData,
-            id: `${Date.now()}-${Math.random().toString(36).substr(2, 9)}`,
-          };
+          const newItem: Reservation = {
+            // 기존 id가 있으면 유지 (API 동기화 시 핵심)
+            id: reservationData.id ?? genId(),
+            title: reservationData.title,
+            room: reservationData.room,
+            date: reservationData.date,
+            time: reservationData.time,
+            endTime: reservationData.endTime,
+            attendees: reservationData.attendees ?? [],
+            status: reservationData.status ?? 'pending',
+          } as Reservation;
 
-          set(state => ({
-            reservations: [...state.reservations, newReservation],
-            loading: false,
-          }));
+          set(state => {
+            const map = new Map<string, Reservation>();
+            // 기존 것들
+            for (const r of state.reservations) {
+              map.set(dedupeKey(r), r);
+            }
+            // 신규(upsert)
+            map.set(dedupeKey(newItem), newItem);
+            return { reservations: Array.from(map.values()), loading: false };
+          });
 
           return true;
         } catch (error) {
@@ -133,30 +169,34 @@ export const useReservationStore = create<ReservationStore>()(
         }
       },
 
-      // 선택된 날짜 설정
-      setSelectedDate: date => {
-        set({ selectedDate: date });
+      // 통째로 교체(중복 뿌리 제거)
+      setReservations: items => {
+        // 들어온 배열을 dedupeKey 기준으로 깨끗이 중복 제거
+        const map = new Map<string, Reservation>();
+        for (const r of items) {
+          map.set(dedupeKey(r), r);
+        }
+        set({ reservations: Array.from(map.values()) });
       },
+
+      clearReservations: () => set({ reservations: [] }),
+
+      // 선택된 날짜 설정
+      setSelectedDate: date => set({ selectedDate: date }),
 
       // 현재 뷰 설정
-      setCurrentView: view => {
-        set({ currentView: view });
-      },
+      setCurrentView: view => set({ currentView: view }),
 
-      // 샘플 데이터 초기화
+      // 샘플 데이터 초기화(유지)
       initializeWithSampleData: () => {
         const { reservations } = get();
         if (reservations.length === 0) {
-          // 샘플 데이터는 여기서 직접 추가하지 않고,
-          // 컴포넌트에서 필요할 때 호출하도록 함
           set({ isInitialized: true });
         }
       },
 
       // 에러 초기화
-      clearError: () => {
-        set({ error: null });
-      },
+      clearError: () => set({ error: null }),
 
       // 회의실 상태 업데이트
       updateRoomStatus: (roomId, status) => {
@@ -168,9 +208,7 @@ export const useReservationStore = create<ReservationStore>()(
       },
 
       // 로딩 상태 설정
-      setLoading: loading => {
-        set({ loading });
-      },
+      setLoading: loading => set({ loading }),
 
       // 특정 날짜의 예약 조회
       getReservationsByDate: date => {
@@ -195,19 +233,21 @@ export const useReservationStore = create<ReservationStore>()(
         return reservations.filter(reservation => reservation.room === room);
       },
 
-      // 오늘 예약 조회
+      // 오늘 예약 조회 (로컬 날짜 기준 "YYYY-MM-DD")
       getTodayReservations: () => {
         const { reservations } = get();
-        const today = new Date().toISOString().split('T')[0];
+        const now = new Date();
+        const y = now.getFullYear();
+        const m = String(now.getMonth() + 1).padStart(2, '0');
+        const d = String(now.getDate()).padStart(2, '0');
+        const today = `${y}-${m}-${d}`;
         return reservations.filter(reservation => reservation.date === today);
       },
 
-      // 대기 중인 예약 조회
+      // 대기 중 예약
       getPendingReservations: () => {
         const { reservations } = get();
-        return reservations.filter(
-          reservation => reservation.status === 'pending'
-        );
+        return reservations.filter(r => r.status === 'pending');
       },
 
       // 특정 회의실 조회
@@ -229,15 +269,12 @@ export const useReservationStore = create<ReservationStore>()(
       },
     }),
     {
-      name: 'reservation-storage', // 로컬 스토리지 키
+      name: 'reservation-storage',
       partialize: state => ({
         reservations: state.reservations,
         rooms: state.rooms,
-        // selectedDate는 세션별로 초기화하는 것이 더 나을 수 있음
-        // selectedDate: state.selectedDate,
-      }), // 뷰 상태는 저장하지 않음
+      }),
       onRehydrateStorage: () => state => {
-        // selectedDate가 문자열로 저장되었다면 Date 객체로 변환
         if (
           state &&
           state.selectedDate &&
@@ -245,10 +282,7 @@ export const useReservationStore = create<ReservationStore>()(
         ) {
           state.selectedDate = new Date(state.selectedDate);
         }
-        // 초기화 플래그는 항상 false로 설정
-        if (state) {
-          state.isInitialized = false;
-        }
+        if (state) state.isInitialized = false;
       },
     }
   )

--- a/placeit-frontend/src/stores/workspaceStore.ts
+++ b/placeit-frontend/src/stores/workspaceStore.ts
@@ -1,25 +1,45 @@
+// stores/workspaceStore.ts
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 import { fetchMyWorkspaces } from '@/services/workspaces';
 
-export type WorkspaceLite = {
-  id: string;
+/** 서버 응답의 최소 형태(우리가 쓰는 필드만) */
+type RawWorkspace = {
+  id: number | string;
   name: string;
+  deleted?: boolean;
+  activeInvitationCode?: string | null;
+  userRole?: 'SUPER_ADMIN' | 'ADMIN' | 'MEMBER' | string;
+};
+
+/** 헤더/대시보드 등에서 쓰는 가벼운 형태 */
+export type WorkspaceLite = {
+  id: string; // 항상 문자열로 통일
+  name: string;
+  userRole?: 'SUPER_ADMIN' | 'ADMIN' | 'MEMBER';
   activeInvitationCode?: string | null;
 };
 
 interface WorkspaceState {
+  /** 사용자/환경에 묶기 위한 키 (예: u:1|https://api...) */
   ownerKey: string | null;
+
+  /** 현재 선택된 워크스페이스 id(문자열) */
   currentId: string | null;
+
+  /** 워크스페이스 목록(정규화된 가벼운 형태) */
   list: WorkspaceLite[];
+
+  /** 마지막으로 목록을 가져온 시각(ms) */
   lastFetched: number | null;
 
+  // actions
   bindToUser: (ownerKey: string | null) => void;
 
   setCurrent: (id: string | number | null) => void;
   setList: (list: WorkspaceLite[]) => void;
 
-  /** 필요할 때만 백그라운드 갱신 */
+  /** 오래됐으면 갱신 (기본 5분) */
   refreshIfStale: (opts?: {
     staleTime?: number;
     signal?: AbortSignal;
@@ -29,6 +49,37 @@ interface WorkspaceState {
   hardRefresh: (signal?: AbortSignal) => Promise<void>;
 }
 
+/* -------------------- helpers -------------------- */
+
+function extractWorkspaces(input: unknown): RawWorkspace[] {
+  // 응답이 { workspaces: [...] } 또는 그냥 배열 둘 다 대응
+  if (Array.isArray(input)) return input as RawWorkspace[];
+  if (input && typeof input === 'object') {
+    const maybe = input as { workspaces?: unknown };
+    if (Array.isArray(maybe.workspaces))
+      return maybe.workspaces as RawWorkspace[];
+  }
+  return [];
+}
+
+function normalizeLite(ws: RawWorkspace): WorkspaceLite {
+  return {
+    id: String(ws.id),
+    name: ws.name ?? '',
+    userRole: (ws.userRole as any) ?? undefined,
+    activeInvitationCode: ws.activeInvitationCode ?? null,
+  };
+}
+
+/** 서버에서 목록을 불러와 가벼운 형태로 정규화 */
+async function loadMyWorkspaces(): Promise<WorkspaceLite[]> {
+  const raw = await fetchMyWorkspaces();
+  const arr = extractWorkspaces(raw).filter(w => !w.deleted); // 삭제된 항목 제외(있다면)
+  return arr.map(normalizeLite);
+}
+
+/* -------------------- store -------------------- */
+
 export const useWorkspaceStore = create<WorkspaceState>()(
   persist(
     (set, get) => ({
@@ -37,103 +88,62 @@ export const useWorkspaceStore = create<WorkspaceState>()(
       list: [],
       lastFetched: null,
 
-      bindToUser: nextKey => {
-        const { ownerKey } = get();
-        if (ownerKey === nextKey) return;
+      bindToUser: (ownerKey: string | null) => {
+        const prev = get().ownerKey;
+        if (prev !== ownerKey) {
+          // 다른 사용자/환경으로 전환되면 목록과 선택값 초기화
+          set({
+            ownerKey,
+            list: [],
+            currentId: null,
+            lastFetched: null,
+          });
+        }
+      },
 
-        // 소유자 변경 → 다른 계정/환경이므로 캐시와 선택값 초기화
-        set({
-          ownerKey: nextKey,
-          currentId: null,
-          list: [],
-          lastFetched: null,
+      setCurrent: (id: string | number | null) =>
+        set({ currentId: id == null ? null : String(id) }),
+
+      setList: (list: WorkspaceLite[]) => set({ list }),
+
+      refreshIfStale: async opts => {
+        const staleTime = opts?.staleTime ?? 5 * 60 * 1000; // 5분
+        const last = get().lastFetched ?? 0;
+        const now = Date.now();
+
+        if (get().list.length > 0 && now - last < staleTime) return;
+
+        const list = await loadMyWorkspaces();
+        set(state => {
+          // currentId가 없으면 첫 번째로 기본 선택
+          const nextCurrent =
+            state.currentId && list.some(w => w.id === state.currentId)
+              ? state.currentId
+              : list[0]?.id ?? null;
+          return { list, currentId: nextCurrent, lastFetched: now };
         });
       },
 
-      setCurrent: id => set({ currentId: id === null ? null : String(id) }),
-      setList: list => set({ list, lastFetched: Date.now() }),
-
-      refreshIfStale: async ({ staleTime = 1000 * 60 * 5, signal } = {}) => {
-        const { ownerKey, lastFetched } = get();
-        if (!ownerKey) return; // 누구에게 바인딩된 상태가 아니면 패스
-
-        const freshEnough = lastFetched && Date.now() - lastFetched < staleTime;
-        if (freshEnough) return;
-
-        const data = await fetchMyWorkspaces(); // axios signal 미사용해도 무방
-        const raw: any[] = Array.isArray(data) ? data : data?.workspaces ?? [];
-
-        const visible = raw
-          .filter(w => !w?.deleted)
-          .map(
-            (w): WorkspaceLite => ({
-              id: String(w.id),
-              name: w.name,
-              // 서버 필드명이 다를 수 있어서 안전망 추가
-              activeInvitationCode:
-                w.activeInvitationCode ?? w.invitationCode ?? w.code ?? null,
-            })
-          );
-
-        if (signal?.aborted) return;
-
-        set({ list: visible, lastFetched: Date.now() });
-
-        const { currentId } = get();
-        if (visible.length > 0) {
-          const exists = visible.some(w => w.id === currentId);
-          if (!exists) set({ currentId: visible[0].id });
-        } else {
-          set({ currentId: null });
-        }
-      },
-
-      hardRefresh: async signal => {
-        const { ownerKey } = get();
-        if (!ownerKey) return;
-
-        const data = await fetchMyWorkspaces();
-        const raw: any[] = Array.isArray(data) ? data : data?.workspaces ?? [];
-
-        const visible = raw
-          .filter(w => !w?.deleted)
-          .map(
-            (w): WorkspaceLite => ({
-              id: String(w.id),
-              name: w.name,
-              activeInvitationCode:
-                w.activeInvitationCode ?? w.invitationCode ?? w.code ?? null,
-            })
-          );
-
-        if (signal?.aborted) return;
-
-        set({ list: visible, lastFetched: Date.now() });
-
-        const { currentId } = get();
-        if (visible.length > 0) {
-          const exists = visible.some(w => w.id === currentId);
-          if (!exists) set({ currentId: visible[0].id });
-        } else {
-          set({ currentId: null });
-        }
+      hardRefresh: async (_signal?: AbortSignal) => {
+        const list = await loadMyWorkspaces();
+        set(state => {
+          const nextCurrent =
+            state.currentId && list.some(w => w.id === state.currentId)
+              ? state.currentId
+              : list[0]?.id ?? null;
+          return { list, currentId: nextCurrent, lastFetched: Date.now() };
+        });
       },
     }),
     {
-      /** 이전 캐시와 구분되도록 키/버전 갱신 */
-      name: 'workspace-storage-v2',
-      version: 2,
-      migrate: (persisted: any, version) => {
-        if (version < 2) {
-          return {
-            ownerKey: null,
-            currentId: null,
-            list: [],
-            lastFetched: null,
-          } as Partial<WorkspaceState>;
-        }
-        return persisted as WorkspaceState;
-      },
+      name: 'workspace-storage',
+      // ownerKey가 바뀌어도 다른 유저 데이터가 섞이지 않도록
+      partialize: state => ({
+        ownerKey: state.ownerKey,
+        currentId: state.currentId,
+        list: state.list,
+        lastFetched: state.lastFetched,
+      }),
     }
   )
 );

--- a/placeit-frontend/src/stores/workspaceStore.ts
+++ b/placeit-frontend/src/stores/workspaceStore.ts
@@ -2,7 +2,11 @@ import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 import { fetchMyWorkspaces } from '@/services/workspaces';
 
-export type WorkspaceLite = { id: string; name: string };
+export type WorkspaceLite = {
+  id: string;
+  name: string;
+  activeInvitationCode?: string | null;
+};
 
 interface WorkspaceState {
   ownerKey: string | null;
@@ -58,9 +62,18 @@ export const useWorkspaceStore = create<WorkspaceState>()(
 
         const data = await fetchMyWorkspaces(); // axios signal 미사용해도 무방
         const raw: any[] = Array.isArray(data) ? data : data?.workspaces ?? [];
+
         const visible = raw
           .filter(w => !w?.deleted)
-          .map(w => ({ id: String(w.id), name: w.name })) as WorkspaceLite[];
+          .map(
+            (w): WorkspaceLite => ({
+              id: String(w.id),
+              name: w.name,
+              // 서버 필드명이 다를 수 있어서 안전망 추가
+              activeInvitationCode:
+                w.activeInvitationCode ?? w.invitationCode ?? w.code ?? null,
+            })
+          );
 
         if (signal?.aborted) return;
 
@@ -81,9 +94,17 @@ export const useWorkspaceStore = create<WorkspaceState>()(
 
         const data = await fetchMyWorkspaces();
         const raw: any[] = Array.isArray(data) ? data : data?.workspaces ?? [];
+
         const visible = raw
           .filter(w => !w?.deleted)
-          .map(w => ({ id: String(w.id), name: w.name })) as WorkspaceLite[];
+          .map(
+            (w): WorkspaceLite => ({
+              id: String(w.id),
+              name: w.name,
+              activeInvitationCode:
+                w.activeInvitationCode ?? w.invitationCode ?? w.code ?? null,
+            })
+          );
 
         if (signal?.aborted) return;
 

--- a/placeit-frontend/src/types/index.ts
+++ b/placeit-frontend/src/types/index.ts
@@ -18,7 +18,7 @@ export interface Reservation {
   time: string;
   endTime?: string;
   attendees: string[];
-  status: 'confirmed' | 'pending' | 'cancelled';
+  status: 'confirmed' | 'pending' | 'cancelled' | 'hidden';
 }
 
 export interface User {

--- a/placeit-frontend/src/types/index.ts
+++ b/placeit-frontend/src/types/index.ts
@@ -13,6 +13,7 @@ export interface Reservation {
   id: string;
   title: string;
   room: string;
+  roomId: string;
   date: string;
   time: string;
   endTime?: string;

--- a/placeit-frontend/src/types/index.ts
+++ b/placeit-frontend/src/types/index.ts
@@ -15,6 +15,7 @@ export interface Reservation {
   room: string;
   date: string;
   time: string;
+  endTime?: string;
   attendees: string[];
   status: 'confirmed' | 'pending' | 'cancelled';
 }


### PR DESCRIPTION
## 상세내용
### 대시보드/예약 페이지
- 예약 조회/생성/수정/삭제/승인/삭제 API 연결
- 상세한 UI/UX 수정
  - 하나의 예약은 하나의 블록으로 보이게 연결
  - 지난 날짜나 시간은 잠궈둠
  - 예약 수정 모달창은 기존 예약 생성 모달창 재사용
### 헤더/사이드바
- 사이드바의 뱃지, 이메일 연동
- 헤더의 사용자 권한, 초대 코드 연동
- 사이드바 환경설정과 헤더의 새로고침 제거