### PR TITLE
Fix: 사용자 관리 페이지의 통계 수정

### DIFF
--- a/placeit-frontend/src/app/(dashboard)/users/page.tsx
+++ b/placeit-frontend/src/app/(dashboard)/users/page.tsx
@@ -131,7 +131,8 @@ export default function UserManagementPage() {
     [rows]
   );
   const adminCount = React.useMemo(
-    () => rows.filter(u => u.role === 'admin').length,
+    () =>
+      rows.filter(u => u.role === 'admin' || u.role === 'super_admin').length,
     [rows]
   );
   const thisMonthNew = React.useMemo(() => {


### PR DESCRIPTION
## 상세 내용
- 기존의 통계 스탯 카드의 관리자 숫자에 최고 관리자(SUPER_ADMIN) 포함 안 되던 문제
- adminCount 함수에 super_admin도 포함시켜서 수정